### PR TITLE
fix: 채팅 에이전트 파일명 확장자 누락 수정 (#18)

### DIFF
--- a/extensions/gitbbon-chat/src/constants/prompts.ts
+++ b/extensions/gitbbon-chat/src/constants/prompts.ts
@@ -32,5 +32,11 @@ When creating notes, ALWAYS provide a meaningful title.
 2. NEVER say "I have created/updated" unless you actually called the tool
 3. Be concise and helpful
 4. Use the provided context to give accurate answers
-5. When using edit_note or read_file, ALWAYS use the exact file path provided in "Active File" or "Open Files" context (e.g., "chapter 1.md"), never strip the file extension
+
+[CRITICAL: File Path Rules]
+- All note files have the .md extension. When calling edit_note or read_file, you MUST include the .md extension in the filePath.
+- Copy the EXACT file path from "Active File" or "Open Files" in the context. Do NOT remove or modify the extension.
+- Example: If Active File is "성수동 역사.md", use filePath: "성수동 역사.md" (NOT "성수동 역사")
+- Example: If Active File is "chapter 1.md", use filePath: "chapter 1.md" (NOT "chapter 1")
+- File paths may contain spaces — this is normal. Do NOT encode or escape spaces.
 `;

--- a/extensions/gitbbon-chat/src/services/ContextService.ts
+++ b/extensions/gitbbon-chat/src/services/ContextService.ts
@@ -173,19 +173,64 @@ export class ContextService {
 	}
 
 	/**
+	 * Convert a file path string to a vscode.Uri.
+	 * Handles both absolute and relative (workspace-relative) paths.
+	 */
+	private static pathToUri(filePath: string): vscode.Uri {
+		if (filePath.startsWith('/') || filePath.match(/^[a-zA-Z]:\\/)) {
+			return vscode.Uri.file(filePath);
+		}
+		const workspaceFolders = vscode.workspace.workspaceFolders;
+		if (!workspaceFolders || workspaceFolders.length === 0) {
+			throw new Error("No workspace folders open");
+		}
+		return vscode.Uri.joinPath(workspaceFolders[0].uri, filePath);
+	}
+
+	/**
+	 * Resolve a file path to a vscode.Uri, with automatic .md extension fallback.
+	 *
+	 * When the AI agent omits the file extension (e.g., sends "chapter 1" instead of
+	 * "chapter 1.md"), this method detects that the path has no extension and
+	 * automatically tries appending ".md" before giving up.
+	 *
+	 * This is the single source of truth for file resolution — used by readFile,
+	 * applySuggestions, and deleteNote.
+	 */
+	private static async resolveFileUri(filePath: string): Promise<vscode.Uri> {
+		const uri = this.pathToUri(filePath);
+
+		// If the path already has a file extension, trust it
+		const hasExtension = /\.[a-zA-Z0-9]+$/.test(filePath);
+		if (hasExtension) {
+			return uri;
+		}
+
+		// No extension detected — try the path as-is first
+		try {
+			await vscode.workspace.fs.stat(uri);
+			return uri;
+		} catch {
+			// Not found without extension — try with .md (the default note format)
+			const mdPath = filePath + '.md';
+			const mdUri = this.pathToUri(mdPath);
+			try {
+				await vscode.workspace.fs.stat(mdUri);
+				console.log(`[gitbbon-chat][Context] Resolved "${filePath}" -> "${mdPath}" (auto-appended .md)`);
+				return mdUri;
+			} catch {
+				// Neither variant exists — throw with both attempted paths
+				throw new Error(`File not found: "${filePath}" (also tried "${mdPath}")`);
+			}
+		}
+	}
+
+	/**
 	 * Reads a specific file from the workspace.
+	 * Automatically appends .md if the path has no extension and the file is not found.
 	 */
 	public static async readFile(filePath: string): Promise<string> {
-		let fileUri: vscode.Uri;
-		if (filePath.startsWith('/') || filePath.match(/^[a-zA-Z]:\\/)) {
-			fileUri = vscode.Uri.file(filePath);
-		} else {
-			const workspaceFolders = vscode.workspace.workspaceFolders;
-			if (!workspaceFolders || workspaceFolders.length === 0) {
-				throw new Error("No workspace folders open");
-			}
-			fileUri = vscode.Uri.joinPath(workspaceFolders[0].uri, filePath);
-		}
+		const fileUri = await this.resolveFileUri(filePath);
 
 		const readData = await vscode.workspace.fs.readFile(fileUri);
 		const content = Buffer.from(readData).toString('utf-8');
@@ -197,11 +242,6 @@ export class ContextService {
 	 * Apply suggestions to a file using Gitbbon Editor's inline suggestion feature.
 	 * If the file is not open, it opens it.
 	 * If it's a markdown file, it tries to use the Gitbbon Editor.
-	 */
-	/**
-	 * Apply suggestions to a file using Gitbbon Editor's inline suggestion feature.
-	 * If the file is not open, it opens it.
-	 * If it's a markdown file, it tries to use the Gitbbon Editor.
 	 * @param mode 'direct' (immediate change) or 'suggestion' (ins/del marks)
 	 */
 	public static async applySuggestions(filePath: string, changes: { oldText: string; newText: string }[], mode: 'direct' | 'suggestion' = 'direct'): Promise<void> {
@@ -209,24 +249,15 @@ export class ContextService {
 			throw new Error("File path is required.");
 		}
 
-		// 1. Resolve URI
-		let uri: vscode.Uri;
-		if (filePath.startsWith('/') || filePath.match(/^[a-zA-Z]:\\/)) {
-			uri = vscode.Uri.file(filePath);
-		} else {
-			const workspaceFolders = vscode.workspace.workspaceFolders;
-			if (!workspaceFolders || workspaceFolders.length === 0) {
-				throw new Error("No workspace folders open");
-			}
-			uri = vscode.Uri.joinPath(workspaceFolders[0].uri, filePath);
-		}
+		// 1. Resolve URI (auto-appends .md if needed)
+		const uri = await this.resolveFileUri(filePath);
 
 		// 2. Open Document (User must see the changes to approve)
 		// Use 'vscode.open' command which respects default editor settings.
 		// If it's a .md file and Gitbbon Editor is default, it will open with it.
 		await vscode.commands.executeCommand('vscode.open', uri);
 
-		// 3. Wait for editor to be active (200ms × 20 = 4초)
+		// 3. Wait for editor to be active (200ms x 20 = 4 seconds)
 		let editorReady = false;
 		for (let i = 0; i < 20; i++) {
 			const activeEditor = vscode.window.activeTextEditor;
@@ -284,6 +315,9 @@ export class ContextService {
 			throw new Error("File path is required.");
 		}
 
+		// Ensure .md extension for new notes
+		const normalizedPath = /\.[a-zA-Z0-9]+$/.test(filePath) ? filePath : filePath + '.md';
+
 		// Build final content with YAML frontmatter if title is provided
 		let finalContent = content;
 		if (title) {
@@ -291,16 +325,7 @@ export class ContextService {
 		}
 
 		// Resolve URI
-		let uri: vscode.Uri;
-		if (filePath.startsWith('/') || filePath.match(/^[a-zA-Z]:\\/)) {
-			uri = vscode.Uri.file(filePath);
-		} else {
-			const workspaceFolders = vscode.workspace.workspaceFolders;
-			if (!workspaceFolders || workspaceFolders.length === 0) {
-				throw new Error("No workspace folders open");
-			}
-			uri = vscode.Uri.joinPath(workspaceFolders[0].uri, filePath);
-		}
+		const uri = this.pathToUri(normalizedPath);
 
 		// Create parent directories if needed
 		const parentDir = vscode.Uri.joinPath(uri, '..');
@@ -322,23 +347,15 @@ export class ContextService {
 
 	/**
 	 * Delete a note file.
+	 * Automatically appends .md if the path has no extension and the file is not found.
 	 */
 	public static async deleteNote(filePath: string): Promise<string> {
 		if (!filePath) {
 			throw new Error("File path is required.");
 		}
 
-		// Resolve URI
-		let uri: vscode.Uri;
-		if (filePath.startsWith('/') || filePath.match(/^[a-zA-Z]:\\/)) {
-			uri = vscode.Uri.file(filePath);
-		} else {
-			const workspaceFolders = vscode.workspace.workspaceFolders;
-			if (!workspaceFolders || workspaceFolders.length === 0) {
-				throw new Error("No workspace folders open");
-			}
-			uri = vscode.Uri.joinPath(workspaceFolders[0].uri, filePath);
-		}
+		// Resolve URI (auto-appends .md if needed)
+		const uri = await this.resolveFileUri(filePath);
 
 		await vscode.workspace.fs.delete(uri);
 		return `Deleted: ${vscode.workspace.asRelativePath(uri)}`;

--- a/extensions/gitbbon-chat/src/tools/editorTools.ts
+++ b/extensions/gitbbon-chat/src/tools/editorTools.ts
@@ -129,9 +129,9 @@ ${detail.after}
 		}),
 
 		read_file: tool({
-			description: 'Read the content of a specific file. Use for "that file" or search results.',
+			description: 'Read the content of a specific file. Use for "that file" or search results. IMPORTANT: include the .md extension for note files.',
 			inputSchema: z.object({
-				filePath: z.string().describe('File path (relative or absolute)'),
+				filePath: z.string().describe('File path with extension (e.g., "notes/chapter 1.md"). Include .md for note files.'),
 			}),
 			execute: async ({ filePath }) => {
 				return withProgress('read_file', { filePath }, emitter, async () => {
@@ -145,10 +145,10 @@ ${detail.after}
 		}),
 
 		edit_note: tool({
-			description: 'Create, Update, or Delete a note file.',
+			description: 'Create, Update, or Delete a note file. IMPORTANT: filePath MUST include the .md extension (e.g., "chapter 1.md", not "chapter 1").',
 			inputSchema: z.object({
 				action: z.enum(['create', 'update', 'delete']).describe('Action type'),
-				filePath: z.string().describe('File path'),
+				filePath: z.string().describe('File path with extension (e.g., "notes/chapter 1.md"). MUST include .md extension.'),
 				title: z.string().optional().describe('For create: Note title (will be placed in YAML frontmatter)'),
 				content: z.string().optional().describe('For create: Note body content (without frontmatter)'),
 				changes: z.array(z.object({


### PR DESCRIPTION
## Summary

채팅 에이전트가 파일 편집/읽기 시 확장자 없는 표시명(예: `chapter 1`)으로 파일을 찾아 실패하는 버그를 수정합니다.

### 변경 사항

**1. 자동 .md 확장자 폴백 (`ContextService.ts`)**
- `resolveFileUri()` 헬퍼 메서드 추가: 확장자 없는 경로가 전달되면 자동으로 `.md`를 붙여 재시도
- `pathToUri()` 헬퍼로 URI 변환 로직 중복 제거
- `readFile()`, `applySuggestions()`, `deleteNote()`, `createNote()` 모두 `resolveFileUri()` 사용
- 공백 포함 파일명 (예: `성수동 역사.md`) 정상 처리

**2. 컨텍스트 정보 개선 (이전 커밋에서 완료)**
- `getActiveFileName()`: `tab.label` 대신 `TabInputCustom.uri` 사용
- `getOpenTabs()`: 모든 탭에서 URI 기반 경로 반환

**3. 프롬프트 강화 (`prompts.ts`, `editorTools.ts`)**
- 시스템 프롬프트에 `[CRITICAL: File Path Rules]` 섹션 추가
- `edit_note`, `read_file` 도구 설명에 `.md` 확장자 필수 명시
- 한국어/공백 포함 파일명 예시 추가

### 방어 전략 (이중 안전장치)
1. **프롬프트 레벨**: AI에게 정확한 파일 경로 사용을 강력히 지시
2. **코드 레벨**: AI가 확장자를 누락하더라도 `resolveFileUri()`가 `.md`를 자동 추가하여 복구

## Test plan
- [ ] 확장자 없는 파일명(`chapter 1`)으로 read_file 호출 시 `chapter 1.md`로 자동 해석 확인
- [ ] 공백 포함 파일명(`성수동 역사.md`) 편집 요청이 정상 동작하는지 확인
- [ ] 기존 확장자 포함 파일명(`chapter 1.md`)이 여전히 정상 동작하는지 확인
- [ ] 새 노트 생성 시 확장자 없이 요청해도 `.md`가 자동 추가되는지 확인

Closes #18