### PR TITLE
feat: Issue #37 - qwen3 thinking 비활성화로 Ollama 응답 속도 개선

### DIFF
--- a/extensions/gitbbon-chat/src/extension.ts
+++ b/extensions/gitbbon-chat/src/extension.ts
@@ -141,6 +141,13 @@ class GitbbonChatViewProvider implements vscode.WebviewViewProvider {
 							event: event
 						});
 						break;
+					case 'thinking-content':
+						// thinking 내용 전송
+						this._webviewView.webview.postMessage({
+							type: 'chat-thinking-content',
+							content: event.content
+						});
+						break;
 					case 'text':
 						// AI 응답 텍스트 전송
 						this._webviewView.webview.postMessage({

--- a/extensions/gitbbon-chat/src/services/aiService.ts
+++ b/extensions/gitbbon-chat/src/services/aiService.ts
@@ -233,13 +233,7 @@ export class AIService {
 
 		const instructions = SYSTEM_PROMPT + '\n\n' + contextParts.join('\n');
 
-		// Ollama thinking 모델 최적화: qwen3 등 thinking 모델은 /no_think로 비활성화
-		let finalInstructions = instructions;
-		if (backend === 'ollama' && ollamaModelName.toLowerCase().includes('qwen')) {
-			finalInstructions = '/no_think\n\n' + instructions;
-		}
-
-		logService.info('[gitbbon-chat][System Prompt]', finalInstructions);
+		logService.info('[gitbbon-chat][System Prompt]', instructions);
 		logService.info(`[gitbbon-chat][aiService] Starting streamText: ${typeof model === 'string' ? model : (model as any).modelId ?? 'ollama'}`);
 
 		// Set up AbortController for cancellation
@@ -264,7 +258,7 @@ export class AIService {
 
 				const result = streamText({
 					model,
-					system: finalInstructions,
+					system: instructions,
 					messages: messages as any,
 					tools,
 					stopWhen: stepCountIs(10),
@@ -305,6 +299,11 @@ export class AIService {
 				});
 
 				// Stream text token by token
+				// <think> 블록 파싱 상태
+				let thinkBuffer = '';
+				let isInThinkBlock = false;
+				let thinkProcessed = false;
+
 				for await (const textChunk of result.textStream) {
 					if (abortController.signal.aborted) break;
 
@@ -320,9 +319,66 @@ export class AIService {
 						});
 					}
 
-					if (textChunk) {
+					if (!textChunk) continue;
+
+					// <think> 블록 처리 (아직 처리 전인 경우만)
+					if (!thinkProcessed) {
+						thinkBuffer += textChunk;
+
+						// 상태 머신으로 파싱
+						while (thinkBuffer.length > 0) {
+							if (!isInThinkBlock) {
+								const startIdx = thinkBuffer.indexOf('<think>');
+								if (startIdx === -1) {
+									// think 태그 없음 - 일반 텍스트 (단, 부분 매치 가능성 체크)
+									const possiblePartial = ['<', '<t', '<th', '<thi', '<thin', '<think'];
+									const mightBePartial = possiblePartial.some(p => thinkBuffer.endsWith(p));
+									if (mightBePartial) break; // 더 기다림
+									// 일반 텍스트로 emit
+									channel.push({ type: 'text', content: thinkBuffer });
+									thinkBuffer = '';
+									thinkProcessed = true;
+									break;
+								}
+								// think 태그 앞의 텍스트
+								const before = thinkBuffer.slice(0, startIdx);
+								if (before) channel.push({ type: 'text', content: before });
+								thinkBuffer = thinkBuffer.slice(startIdx + '<think>'.length);
+								isInThinkBlock = true;
+							} else {
+								// think 블록 내부
+								const endIdx = thinkBuffer.indexOf('</think>');
+								if (endIdx === -1) {
+									// 아직 닫히지 않음 - thinking-content emit
+									if (thinkBuffer.length > 0) {
+										channel.push({ type: 'thinking-content', content: thinkBuffer });
+										thinkBuffer = '';
+									}
+									break;
+								}
+								// think 블록 종료
+								const thinkContent = thinkBuffer.slice(0, endIdx);
+								if (thinkContent) channel.push({ type: 'thinking-content', content: thinkContent });
+								thinkBuffer = thinkBuffer.slice(endIdx + '</think>'.length);
+								isInThinkBlock = false;
+								thinkProcessed = true;
+								// </think> 뒤의 텍스트가 있으면 일반 텍스트로
+								if (thinkBuffer.length > 0) {
+									channel.push({ type: 'text', content: thinkBuffer });
+									thinkBuffer = '';
+								}
+								break;
+							}
+						}
+					} else {
+						// think 블록 처리 완료 - 일반 텍스트
 						channel.push({ type: 'text', content: textChunk });
 					}
+				}
+
+				// 루프 종료 후 버퍼 처리
+				if (thinkBuffer.length > 0) {
+					channel.push({ type: isInThinkBlock ? 'thinking-content' : 'text', content: thinkBuffer });
 				}
 
 				logService.info('[gitbbon-chat][AI Response] Streaming complete');

--- a/extensions/gitbbon-chat/src/types.ts
+++ b/extensions/gitbbon-chat/src/types.ts
@@ -28,7 +28,12 @@ export interface TextEvent {
 	content: string;
 }
 
-export type StreamEvent = ToolStartEvent | ToolEndEvent | TextEvent;
+export interface ThinkingContentEvent {
+	type: 'thinking-content';
+	content: string;
+}
+
+export type StreamEvent = ToolStartEvent | ToolEndEvent | TextEvent | ThinkingContentEvent;
 
 /**
  * Tool Event Emitter interface

--- a/extensions/gitbbon-chat/src/webview/App.tsx
+++ b/extensions/gitbbon-chat/src/webview/App.tsx
@@ -16,6 +16,7 @@ const App: React.FC = () => {
 	const [inputValue, setInputValue] = useState('');
 	const [isSending, setIsSending] = useState(false); // 전송 중 상태
 	const [isReceiving, setIsReceiving] = useState(false); // 수신 중 상태
+	const [thinkingContent, setThinkingContent] = useState(''); // thinking 내용
 	const [currentBackend, setCurrentBackend] = useState<'api' | 'ollama'>('api');
 	const [ollamaStatus, setOllamaStatus] = useState<{ step: string; detail: string; progress?: number } | null>(null);
 	const inputRef = useRef<HTMLTextAreaElement>(null);
@@ -55,6 +56,7 @@ const App: React.FC = () => {
 		setIsSending(true);
 		toolStatusMapRef.current.clear();
 		currentAssistantContentRef.current = '';
+		setThinkingContent('');
 		lastUserMessageRef.current = userContent;
 
 		const allMessages = [...currentMessages, userMessage]
@@ -113,6 +115,7 @@ const App: React.FC = () => {
 		setIsSending(false);
 		setIsReceiving(false);
 		currentAssistantContentRef.current = '';
+		setThinkingContent('');
 	}, []);
 
 	// 새 대화 시작
@@ -122,6 +125,7 @@ const App: React.FC = () => {
 		setIsSending(false);
 		setIsReceiving(false);
 		currentAssistantContentRef.current = '';
+		setThinkingContent('');
 		toolStatusMapRef.current.clear();
 		lastUserMessageRef.current = '';
 	}, []);
@@ -230,6 +234,10 @@ const App: React.FC = () => {
 					currentAssistantContentRef.current = '';
 					break;
 
+				case 'chat-thinking-content':
+					setThinkingContent(prev => prev + message.content);
+					break;
+
 				case 'insertText':
 					if (message.text) {
 						setInputValue((prev) => prev + message.text);
@@ -284,7 +292,7 @@ const App: React.FC = () => {
 					)}
 				</div>
 			)}
-			<MessageList messages={messages} isLoading={isSending || isReceiving} onRetry={handleRetry} />
+			<MessageList messages={messages} isLoading={isSending || isReceiving} onRetry={handleRetry} thinkingContent={thinkingContent} />
 			<ChatInput
 				inputValue={inputValue}
 				setInputValue={setInputValue}

--- a/extensions/gitbbon-chat/src/webview/components/MessageList.tsx
+++ b/extensions/gitbbon-chat/src/webview/components/MessageList.tsx
@@ -123,6 +123,7 @@ interface MessageListProps {
 	messages: ChatMessage[];
 	isLoading: boolean;
 	onRetry?: () => void;
+	thinkingContent?: string;
 }
 
 // system 메시지 content를 파싱하여 tool status 또는 error인지 판별
@@ -188,7 +189,7 @@ const ErrorMessage: React.FC<{ message: string; onRetry?: () => void }> = ({ mes
 	);
 };
 
-const MessageList: React.FC<MessageListProps> = ({ messages, isLoading, onRetry }) => {
+const MessageList: React.FC<MessageListProps> = ({ messages, isLoading, onRetry, thinkingContent }) => {
 	const messagesEndRef = useRef<HTMLDivElement>(null);
 
 	// Auto scroll to bottom when messages change
@@ -249,6 +250,12 @@ const MessageList: React.FC<MessageListProps> = ({ messages, isLoading, onRetry 
 				<div className="message-wrapper assistant">
 					<div className="message-bubble assistant">
 						<strong>AI:</strong> <span className="loading-text">생각 중...</span>
+					{thinkingContent && (
+						<details className="thinking-block" open>
+							<summary>추론 과정 보기</summary>
+							<pre className="thinking-content">{thinkingContent}</pre>
+						</details>
+					)}
 					</div>
 				</div>
 			)}


### PR DESCRIPTION
## 개요
Closes #37

## 변경사항
- /no_think 방식 → <think> 토큰 파싱으로 교체
- types.ts: ThinkingContentEvent 타입 추가
- aiService.ts: <think>...</think> 스트림 파싱
- extension.ts: chat-thinking-content 메시지 전달
- App.tsx: thinkingContent 상태 관리
- MessageList.tsx: 추론 과정 collapsible 블록으로 표시