### PR TITLE
fix: Issue #35 - delete log file 후 output 로그 즉시 표시

### DIFF
--- a/src/vs/workbench/contrib/output/common/outputChannelModel.ts
+++ b/src/vs/workbench/contrib/output/common/outputChannelModel.ts
@@ -200,6 +200,9 @@ class FileContentProvider extends Disposable implements IContentProvider {
 			if (toFileOperationResult(error) !== FileOperationResult.FILE_NOT_FOUND) {
 				throw error;
 			}
+			// gitbbon fix: Issue #35 - 파일이 삭제된 경우 etag를 초기화하여
+			// 파일이 다시 생성될 때 변경이 즉시 감지되도록 함
+			this.etag = undefined;
 		}
 	}
 


### PR DESCRIPTION
## 개요
Closes #35

## 변경사항
- `FileContentProvider.doWatch()`에서 `FILE_NOT_FOUND` 에러 발생 시 `etag`를 `undefined`로 초기화

## 버그 원인
`doWatch()`는 파일이 삭제되면 `FILE_NOT_FOUND` 에러를 무시하고 계속 폴링합니다.
그러나 `etag`가 초기화되지 않은 채(`''`) 유지됩니다.

이후 앱이 새 로그 파일을 생성할 때, 만약 새 파일의 `etag`가 기존 `etag`와 동일하면 변경이 감지되지 않아 로그가 표시되지 않습니다.

## 수정 내용
파일이 존재하지 않을 때(`FILE_NOT_FOUND`) `etag`를 `undefined`로 리셋합니다.
이를 통해 파일이 다시 생성되면 새 `etag !== undefined`가 되어 항상 변경으로 감지됩니다.

**변경 파일**: `src/vs/workbench/contrib/output/common/outputChannelModel.ts`