### PR TITLE
feat: Issue #46 - Extension Host 런타임 에러 스택에 source-map 적용

### DIFF
--- a/extensions/gitbbon-chat/package-lock.json
+++ b/extensions/gitbbon-chat/package-lock.json
@@ -10,6 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@types/react-syntax-highlighter": "^15.5.13",
+        "@types/source-map-support": "^0.5.10",
         "ai": "^6.0.3",
         "dotenv": "^17.2.3",
         "react": "^19.2.3",
@@ -17,6 +18,7 @@
         "react-markdown": "^10.1.0",
         "react-syntax-highlighter": "^16.1.1",
         "remark-gfm": "^4.0.1",
+        "source-map-support": "^0.5.21",
         "zod": "^4.2.1"
       },
       "devDependencies": {
@@ -1328,6 +1330,15 @@
         "@types/react": "*"
       }
     },
+    "node_modules/@types/source-map-support": {
+      "version": "0.5.10",
+      "resolved": "https://registry.npmjs.org/@types/source-map-support/-/source-map-support-0.5.10.tgz",
+      "integrity": "sha512-tgVP2H469x9zq34Z0m/fgPewGhg/MLClalNOiPIzQlXrSS2YrKu/xCdSCKnEDwkFha51VKEKB6A9wW26/ZNwzA==",
+      "license": "MIT",
+      "dependencies": {
+        "source-map": "^0.6.0"
+      }
+    },
     "node_modules/@types/unist": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
@@ -1477,6 +1488,12 @@
       "engines": {
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
+    },
+    "node_modules/buffer-from": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+      "license": "MIT"
     },
     "node_modules/caniuse-lite": {
       "version": "1.0.30001761",
@@ -3212,6 +3229,15 @@
         "semver": "bin/semver.js"
       }
     },
+    "node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -3220,6 +3246,16 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/source-map-support": {
+      "version": "0.5.21",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
+      "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "source-map": "^0.6.0"
       }
     },
     "node_modules/space-separated-tokens": {

--- a/extensions/gitbbon-chat/package.json
+++ b/extensions/gitbbon-chat/package.json
@@ -90,6 +90,7 @@
   },
   "dependencies": {
     "@types/react-syntax-highlighter": "^15.5.13",
+    "@types/source-map-support": "^0.5.10",
     "ai": "^6.0.3",
     "dotenv": "^17.2.3",
     "react": "^19.2.3",
@@ -97,6 +98,7 @@
     "react-markdown": "^10.1.0",
     "react-syntax-highlighter": "^16.1.1",
     "remark-gfm": "^4.0.1",
+    "source-map-support": "^0.5.21",
     "zod": "^4.2.1"
   }
 }

--- a/extensions/gitbbon-chat/src/extension.ts
+++ b/extensions/gitbbon-chat/src/extension.ts
@@ -4,6 +4,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import 'source-map-support/register';
 import * as vscode from 'vscode';
 import { type ModelMessage } from 'ai';
 import { AIService } from './services/aiService';


### PR DESCRIPTION
## 개요
Closes #46

## 변경사항
- extensions/gitbbon-chat에 source-map-support 패키지 추가
- extension.ts 진입점에 source-map-support/register 추가

## 효과
런타임 에러 스택 트레이스에서 컴파일된 JS 경로 대신 TypeScript 소스 경로가 표시됨