### PR TITLE
feat: 앱 재시작 후 모델 타입 선택 옵션 복원 (Issue #55)

### DIFF
--- a/extensions/gitbbon-chat/src/extension.ts
+++ b/extensions/gitbbon-chat/src/extension.ts
@@ -76,8 +76,25 @@ class GitbbonChatViewProvider implements vscode.WebviewViewProvider {
 				webviewView.webview.postMessage({ type: 'ollama-models', models });
 			} else if (message.type === 'setup-ollama') {
 				await setupOllama(this.aiService, webviewView);
+			} else if (message.type === 'save-selected-model') {
+				// gitbbon custom: 온디바이스 모델 선택값 저장
+				await this._context.globalState.update('SELECTED_OLLAMA_MODEL', message.model);
 			}
 		});
+
+		// gitbbon custom: 웹뷰 init 시 저장된 backend 및 선택된 모델 복원
+		(async () => {
+			const savedBackend = await this.aiService.getBackend();
+			webviewView.webview.postMessage({ type: 'backend-changed', backend: savedBackend });
+			if (savedBackend === 'ollama') {
+				const models = await ollamaService.getInstalledModels();
+				webviewView.webview.postMessage({ type: 'ollama-models', models });
+				const savedModel = this._context.globalState.get<string>('SELECTED_OLLAMA_MODEL', '');
+				if (savedModel) {
+					webviewView.webview.postMessage({ type: 'selected-model', model: savedModel });
+				}
+			}
+		})();
 
 		// 대기 중인 텍스트가 있으면 삽입
 		if (this._pendingText) {

--- a/extensions/gitbbon-chat/src/webview/App.tsx
+++ b/extensions/gitbbon-chat/src/webview/App.tsx
@@ -137,6 +137,12 @@ const App: React.FC = () => {
 		// byok는 아직 미구현 — 선택만 저장
 	}, []);
 
+	// gitbbon custom: 모델 선택 변경 시 extension에 저장
+	const handleModelSelect = useCallback((model: string) => {
+		setSelectedModel(model);
+		vscode.postMessage({ type: 'save-selected-model', model });
+	}, []);
+
 	// 새 대화 시작
 	const handleNewChat = useCallback(() => {
 		setMessages([]);
@@ -160,8 +166,17 @@ const App: React.FC = () => {
 
 				case 'backend-changed':
 					setCurrentBackend(message.backend as 'api' | 'ollama');
+					// gitbbon custom: 저장된 backend로 modelType UI 복원
+					setModelType(message.backend === 'ollama' ? 'ondevice' : 'gitbbon');
 					if (message.backend !== 'ollama') {
 						setOllamaStatus(null);
+					}
+					break;
+
+				// gitbbon custom: 저장된 선택 모델 복원
+				case 'selected-model':
+					if (message.model) {
+						setSelectedModel(message.model);
 					}
 					break;
 
@@ -317,7 +332,7 @@ const App: React.FC = () => {
 				modelType={modelType}
 				setModelType={handleModelTypeChange}
 				selectedModel={selectedModel}
-				setSelectedModel={setSelectedModel}
+				setSelectedModel={handleModelSelect}
 				ollamaModels={ollamaModels.length > 0 ? ollamaModels : FALLBACK_OLLAMA_MODELS}
 			/>
 		</div>


### PR DESCRIPTION
## 개요
Closes #55

## 변경사항
- `extension.ts`: webview init 시 저장된 backend 상태를 웹뷰에 전송. ollama backend인 경우 설치 모델 목록 및 저장된 선택 모델도 함께 전송
- `extension.ts`: `save-selected-model` 메시지 처리 추가 — 웹뷰에서 모델 선택 시 `globalState`에 저장
- `App.tsx`: `backend-changed` 핸들러에서 `setModelType` 호출 추가 — backend 값에 따라 UI modelType 복원
- `App.tsx`: `selected-model` 수신 처리 추가 — 저장된 ollama 선택 모델 복원
- `App.tsx`: `handleModelSelect` 콜백 추가 — 모델 선택 시 extension에 `save-selected-model` 메시지 전송