### PR TITLE
fix: 온디바이스 ollama 미설치/미실행 시 모델 관련 문제 수정 (Issue #56)

### DIFF
--- a/extensions/gitbbon-chat/src/extension.ts
+++ b/extensions/gitbbon-chat/src/extension.ts
@@ -63,7 +63,9 @@ class GitbbonChatViewProvider implements vscode.WebviewViewProvider {
 		// 웹뷰에서 메시지 수신
 		webviewView.webview.onDidReceiveMessage(async (message) => {
 			if (message.type === 'chat-request') {
-				await this._handleChatMessage(message.messages);
+				// gitbbon custom: UI 선택 모델 추출
+				const { messages: chatMessages, selectedModel } = message;
+				await this._handleChatMessage(chatMessages, selectedModel);
 			} else if (message.type === 'chat-cancel') {
 				this.aiService.cancelCurrentStream();
 				webviewView.webview.postMessage({ type: 'chat-done' });
@@ -103,7 +105,7 @@ class GitbbonChatViewProvider implements vscode.WebviewViewProvider {
 		}
 	}
 
-	private async _handleChatMessage(messages: ModelMessage[]): Promise<void> {
+	private async _handleChatMessage(messages: ModelMessage[], selectedModel?: string): Promise<void> {
 		if (!this._webviewView) {
 			return;
 		}
@@ -126,7 +128,8 @@ class GitbbonChatViewProvider implements vscode.WebviewViewProvider {
 		}
 
 		try {
-			const stream = this.aiService.streamAgentChat(messages);
+			// gitbbon custom: UI 선택 모델을 aiService에 전달
+			const stream = this.aiService.streamAgentChat(messages, selectedModel);
 
 			for await (const event of stream) {
 				switch (event.type) {

--- a/extensions/gitbbon-chat/src/services/aiService.ts
+++ b/extensions/gitbbon-chat/src/services/aiService.ts
@@ -184,7 +184,7 @@ export class AIService {
 		return success;
 	}
 
-	public async *streamAgentChat(messages: ModelMessage[]): AsyncGenerator<StreamEvent, void, unknown> {
+	public async *streamAgentChat(messages: ModelMessage[], selectedModel?: string): AsyncGenerator<StreamEvent, void, unknown> {
 		const backend = await this.getBackend();
 		if (backend !== 'ollama') {
 			await this.ensureInitialized();
@@ -214,8 +214,9 @@ export class AIService {
 		// Resolve model: Ollama returns a LanguageModel object; API backend uses a gateway string ID
 		let model: LanguageModel | string;
 		if (backend === 'ollama') {
-			const ollamaModelName = await ollamaService.getSelectedModel();
-			logService.info(`[gitbbon-chat][aiService] Ollama backend: model=${ollamaModelName}`);
+			// gitbbon custom: UI에서 선택한 모델을 우선 사용, 없으면 설치된 첫 번째 모델 또는 하드웨어 기반 선택
+			const ollamaModelName = selectedModel || await ollamaService.getSelectedModel();
+			logService.info(`[gitbbon-chat][aiService] Ollama backend: model=${ollamaModelName} (selectedModel=${selectedModel || 'none'})`);
 			const ollamaProvider = createOpenAI({ baseURL: 'http://localhost:11434/v1', apiKey: 'ollama' });
 			model = ollamaProvider.chat(ollamaModelName);
 		} else {
@@ -419,8 +420,8 @@ export class AIService {
 		await agentPromise;
 	}
 
-	public async *streamChat(messages: ModelMessage[]): AsyncGenerator<StreamEvent, void, unknown> {
-		yield* this.streamAgentChat(messages);
+	public async *streamChat(messages: ModelMessage[], selectedModel?: string): AsyncGenerator<StreamEvent, void, unknown> {
+		yield* this.streamAgentChat(messages, selectedModel);
 	}
 
 }

--- a/extensions/gitbbon-chat/src/webview/App.tsx
+++ b/extensions/gitbbon-chat/src/webview/App.tsx
@@ -74,11 +74,13 @@ const App: React.FC = () => {
 				content: m.content,
 			}));
 
+		// gitbbon custom: 선택된 모델을 extension에 전달
 		vscode.postMessage({
 			type: 'chat-request',
 			messages: allMessages,
+			selectedModel,
 		});
-	}, []);
+	}, [selectedModel]);
 
 	// 메시지 전송
 	const handleSubmit = useCallback((e: React.FormEvent) => {
@@ -124,6 +126,15 @@ const App: React.FC = () => {
 		setIsReceiving(false);
 		currentAssistantContentRef.current = '';
 	}, []);
+
+	// gitbbon custom: ollamaModels 변경 시 selectedModel 동기화
+	useEffect(() => {
+		if (modelType === 'ondevice' && ollamaModels.length > 0) {
+			if (!ollamaModels.includes(selectedModel)) {
+				setSelectedModel(ollamaModels[0]);
+			}
+		}
+	}, [ollamaModels, modelType]);
 
 	// gitbbon custom: 모델타입 셀렉트 변경 시 백엔드 전환 메시지 전송
 	const handleModelTypeChange = useCallback((type: ModelType) => {


### PR DESCRIPTION
## 개요
Closes #56

## 변경사항
- App.tsx: ollamaModels 변경 시 selectedModel 자동 동기화 (useEffect 추가)
- App.tsx: chat-request에 selectedModel 포함하여 extension에 전달
- extension.ts: chat-request에서 selectedModel 추출 후 aiService에 전달
- aiService.ts: streamAgentChat/streamChat에 selectedModel 파라미터 추가, ollama 백엔드 사용 시 UI 선택 모델을 우선 사용

## 수정된 문제
1. UI 선택 모델이 실제 채팅에 사용되지 않던 문제 — selectedModel을 chat-request 메시지에 포함하고 extension → aiService 경로로 전달
2. ollamaModels 변경 시 selectedModel 자동 업데이트 없던 문제 — useEffect로 동기화
3. (기존 FALLBACK_OLLAMA_MODELS 표시 로직은 유지하되, 이제 selectedModel이 올바르게 전달되므로 실제 설치 모델과 불일치 혼란 감소)