### PR TITLE
feat: Issue #61 - Commit 버튼 UX 개선

### DIFF
--- a/extensions/gitbbon-editor/src/editorProvider.ts
+++ b/extensions/gitbbon-editor/src/editorProvider.ts
@@ -706,8 +706,9 @@ export class GitbbonEditorProvider implements vscode.CustomTextEditorProvider {
 							vscode.commands.executeCommand('_gitbbon.upsertFloatingWidget', {
 								id: 'gitbbon-main',
 								type: 'button',
-								icon: 'codicon codicon-check',
-								label: 'Save',
+								// gitbbon custom: git commit 의미에 맞는 아이콘으로 변경 (Issue #61)
+								icon: 'codicon codicon-git-commit',
+								label: 'Commit',
 								tooltip: 'Unsaved changes - click to save',
 								command: 'gitbbon.manager.reallyFinal',
 								priority: 10,
@@ -718,8 +719,9 @@ export class GitbbonEditorProvider implements vscode.CustomTextEditorProvider {
 							vscode.commands.executeCommand('_gitbbon.upsertFloatingWidget', {
 								id: 'gitbbon-main',
 								type: 'button',
-								icon: 'codicon codicon-check',
-								label: 'Saved',
+								// gitbbon custom: git commit 의미에 맞는 아이콘으로 변경 (Issue #61)
+								icon: 'codicon codicon-git-commit',
+								label: 'Committed',
 								tooltip: 'All changes saved',
 								priority: 10,
 								dimmed: true

--- a/src/vs/workbench/browser/media/style.css
+++ b/src/vs/workbench/browser/media/style.css
@@ -31,15 +31,16 @@
 	display: flex;
 	flex-direction: row; /* Icon and label side by side */
 	align-items: center;
-	padding: 10px 20px;
+	/* gitbbon custom: 버튼 크기 축소 및 pill 형태로 변경 (Issue #61) */
+	padding: 8px 18px;
 	background-color: var(--vscode-button-background);
 	color: var(--vscode-button-foreground);
-	border-radius: 6px;
+	/* gitbbon custom: pill 형태로 border-radius 변경 (Issue #61) */
+	border-radius: 20px;
 	cursor: pointer;
 	gap: 10px;
 	box-shadow: 0 4px 8px rgba(0, 0, 0, 0.3);
 	transition: background-color 0.2s ease;
-	min-width: 140px; /* Ensure consistent width for short labels */
 	justify-content: center; /* Center content */
 }
 
@@ -50,7 +51,7 @@
 .gitbbon-floating-widget span.label {
 	font-size: 11px;
 	font-weight: 600;
-	text-transform: uppercase;
+	/* gitbbon custom: uppercase 제거, 자연스러운 텍스트 케이스 적용 (Issue #61) */
 }
 
 /* Dimmed state (no pending changes) */
@@ -58,10 +59,8 @@
 	opacity: 0.5;
 	cursor: default;
 	pointer-events: none; /* Disable clicks */
-}
-
-.gitbbon-floating-widget.dimmed:hover {
-	background-color: var(--vscode-button-background);
+	/* gitbbon custom: dimmed 상태에서 완전히 숨김 (Issue #61) */
+	display: none;
 }
 
 /* High Contrast Adjustments */

--- a/src/vs/workbench/browser/workbench.ts
+++ b/src/vs/workbench/browser/workbench.ts
@@ -66,7 +66,8 @@ export interface IWorkbenchOptions {
 }
 
 // gitbbon custom: Floating Widget System - add dynamic floating button layer to editor area (centered)
-const FLOATING_WIDGET_BOTTOM = 30;
+// gitbbon custom: 하단 여백 확보를 위해 bottom 값 증가 (Issue #61)
+const FLOATING_WIDGET_BOTTOM = 40;
 
 export class Workbench extends Layout {
 
@@ -432,7 +433,8 @@ export class Workbench extends Layout {
 		// Initialize Single Main Widget (Saved state, dimmed)
 		this.floatingWidgets.set('gitbbon-main', {
 			type: 'button',
-			icon: 'codicon codicon-check',
+			// gitbbon custom: git commit 의미에 맞는 아이콘으로 변경 (Issue #61)
+			icon: 'codicon codicon-git-commit',
 			label: 'Saved',
 			tooltip: 'All changes saved',
 			priority: 10,


### PR DESCRIPTION
## 개요
Closes #61

## 변경사항
- 아이콘: `codicon-check` → `codicon-git-commit` (의미 명확화)
- 형태: `border-radius: 6px` → `border-radius: 20px` (pill 형태)
- 크기: `min-width: 140px` 제거, `padding: 8px 18px` (컴팩트)
- 텍스트: `text-transform: uppercase` 제거 → Commit / Committed
- dimmed: `display: none` 추가 (변경사항 없을 때 버튼 숨김)
- 위치: `bottom: 30px` → `bottom: 40px`