### PR TITLE
fix: 전송 버튼 아이콘 hover 시 이동 현상 제거

### DIFF
--- a/extensions/gitbbon-chat/src/webview/index.css
+++ b/extensions/gitbbon-chat/src/webview/index.css
@@ -448,9 +448,7 @@ body {
 	transition: transform 0.3s ease;
 }
 
-.chat-submit-btn:hover:not(:disabled):not(.sending):not(.receiving) svg {
-	transform: translateX(2px);
-}
+/* gitbbon custom: Issue #72 - hover 시 아이콘 이동 제거 (translateX(2px) 삭제) */
 
 /* Stop 버튼 스타일 */
 .chat-submit-btn.stop {


### PR DESCRIPTION
## Summary
- 채팅창 전송 버튼의 아이콘(화살표)이 hover 시 `translateX(2px)`로 오른쪽으로 이동하던 CSS 규칙을 제거
- 버튼 자체의 `scale(1.1)` transform은 유지

## Test plan
- [ ] 채팅창 전송 버튼에 마우스를 올렸을 때 아이콘이 이동하지 않는지 확인
- [ ] 전송 버튼 hover 시 버튼 크기 확대(scale) 효과는 정상 동작하는지 확인
- [ ] stop 버튼 hover 효과도 정상인지 확인

Closes #72

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>