### PR TITLE
feat: Issue #79 - 온디바이스 모델 삭제 기능 추가

### DIFF
--- a/extensions/gitbbon-chat/src/extension.ts
+++ b/extensions/gitbbon-chat/src/extension.ts
@@ -100,6 +100,32 @@ class GitbbonChatViewProvider implements vscode.WebviewViewProvider {
 				const models = await ollamaService.getRecommendedModels();
 				const freeDiskGB = await ollamaService.getFreeDiskGB();
 				webviewView.webview.postMessage({ type: 'recommended-models', models, freeDiskGB });
+			} else if (message.type === 'delete-ollama-model') {
+				// Issue #79: 온디바이스 모델 삭제 요청 처리
+				const modelName = message.model as string;
+				logService.info(`[debug:#79] 모델 삭제 요청 수신: ${modelName}`);
+				webviewView.webview.postMessage({ type: 'model-delete-progress', model: modelName, status: 'deleting' });
+				try {
+					await ollamaService.deleteModel(modelName);
+					logService.info(`[debug:#79] 삭제 완료, 목록 갱신: ${modelName}`);
+					webviewView.webview.postMessage({ type: 'model-delete-progress', model: modelName, status: 'done' });
+					// 삭제 완료 후 추천 모델 목록 갱신
+					const updatedModels = await ollamaService.getRecommendedModels();
+					const freeDiskGB = await ollamaService.getFreeDiskGB();
+					webviewView.webview.postMessage({ type: 'recommended-models', models: updatedModels, freeDiskGB });
+					// 설치된 모델 목록도 capabilities 포함하여 갱신
+					const installedModelsWithCaps = await ollamaService.getInstalledModelsWithCapabilities();
+					const installedModels = installedModelsWithCaps.map(m => m.name);
+					const installedCaps: Record<string, { thinking: boolean; tools: boolean; completion: boolean }> = {};
+					for (const m of installedModelsWithCaps) {
+						installedCaps[m.name] = m.capabilities;
+					}
+					this._modelCapabilities = { ...this._modelCapabilities, ...installedCaps };
+					webviewView.webview.postMessage({ type: 'ollama-models', models: installedModels, capabilities: installedCaps });
+				} catch (err) {
+					logService.error(`[debug:#79] 모델 삭제 실패: ${modelName}`, err);
+					webviewView.webview.postMessage({ type: 'model-delete-progress', model: modelName, status: 'error', message: String(err) });
+				}
 			} else if (message.type === 'pull-ollama-model') {
 				// gitbbon custom: Issue #69 - 미설치 모델 다운로드 요청 (상태표시줄 진행률 표시)
 				const modelName = message.model as string;

--- a/extensions/gitbbon-chat/src/services/ollamaService.ts
+++ b/extensions/gitbbon-chat/src/services/ollamaService.ts
@@ -336,6 +336,44 @@ export class OllamaService {
     }
   }
 
+  // Issue #79: DELETE /api/delete 엔드포인트로 모델 삭제
+  async deleteModel(modelName: string): Promise<void> {
+    logService.info(`[debug:#79] 모델 삭제 요청: ${modelName}`);
+    return new Promise((resolve, reject) => {
+      const body = JSON.stringify({ name: modelName });
+      const options: http.RequestOptions = {
+        hostname: 'localhost',
+        port: 11434,
+        path: '/api/delete',
+        method: 'DELETE',
+        headers: {
+          'Content-Type': 'application/json',
+          'Content-Length': Buffer.byteLength(body),
+        },
+      };
+
+      const req = http.request(options, (res) => {
+        res.resume();
+        if (res.statusCode === 200) {
+          logService.info(`[debug:#79] 모델 삭제 완료: ${modelName}`);
+          resolve();
+        } else {
+          const err = new Error(`DELETE /api/delete 실패: status=${res.statusCode}`);
+          logService.error(`[debug:#79] 모델 삭제 실패: ${modelName}`, err);
+          reject(err);
+        }
+      });
+
+      req.on('error', (err) => {
+        logService.error(`[debug:#79] 모델 삭제 요청 오류: ${modelName}`, err);
+        reject(err);
+      });
+
+      req.write(body);
+      req.end();
+    });
+  }
+
   async pullModel(model: string, onProgress: (pct: number) => void): Promise<void> {
     logService.info(`[ollamaService] pullModel: starting ${model}`);
     return new Promise((resolve, reject) => {

--- a/extensions/gitbbon-chat/src/webview/App.tsx
+++ b/extensions/gitbbon-chat/src/webview/App.tsx
@@ -36,6 +36,13 @@ export interface ModelPullStatus {
 	status: 'pulling' | 'done' | 'error';
 }
 
+// Issue #79: 모델 삭제 진행 상태
+export interface ModelDeleteStatus {
+	model: string;
+	status: 'deleting' | 'done' | 'error';
+	message?: string;
+}
+
 // ollama 모델명 폴백 목록 (설치된 모델 없을 때 사용)
 const FALLBACK_OLLAMA_MODELS = ['llama3.1:8b', 'llama3.2:3b', 'llama3.2:1b', 'gemma2:2b', 'gemma2:9b', 'phi3:mini', 'mistral:7b', 'qwen2.5:7b', 'qwen2.5:3b'];
 
@@ -57,6 +64,10 @@ const App: React.FC = () => {
 	// Issue #77: 모델별 capabilities 상태
 	const [modelCapabilities, setModelCapabilities] = useState<Record<string, ModelCapabilities>>({});
 	const [downloadConfirm, setDownloadConfirm] = useState<RecommendedModel | null>(null);
+	// Issue #79: 모델 관리 모달 상태
+	const [modelManageOpen, setModelManageOpen] = useState(false);
+	const [modelDeleteStatus, setModelDeleteStatus] = useState<ModelDeleteStatus | null>(null);
+	const [deleteConfirmModel, setDeleteConfirmModel] = useState<RecommendedModel | null>(null);
 	const inputRef = useRef<HTMLTextAreaElement>(null);
 	const currentAssistantContentRef = useRef(''); // 스트리밍 콘텐츠 추적용
 	const currentReasoningContentRef = useRef(''); // Issue #64: reasoning 콘텐츠 추적용
@@ -206,6 +217,24 @@ const App: React.FC = () => {
 	const handleCancelDownload = useCallback(() => {
 		setDownloadConfirm(null);
 	}, []);
+
+	// Issue #79: 모델 삭제 요청
+	const handleDeleteModel = useCallback((model: RecommendedModel) => {
+		setDeleteConfirmModel(model);
+	}, []);
+
+	// Issue #79: 삭제 확인 다이얼로그 취소
+	const handleCancelDelete = useCallback(() => {
+		setDeleteConfirmModel(null);
+	}, []);
+
+	// Issue #79: 삭제 확인 후 실제 삭제 요청 전송
+	const handleConfirmDelete = useCallback(() => {
+		if (!deleteConfirmModel) return;
+		const modelName = deleteConfirmModel.name;
+		setDeleteConfirmModel(null);
+		vscode.postMessage({ type: 'delete-ollama-model', model: modelName });
+	}, [deleteConfirmModel]);
 
 	// 새 대화 시작
 	const handleNewChat = useCallback(() => {
@@ -395,7 +424,31 @@ const App: React.FC = () => {
 					}
 					break;
 
-				// gitbbon custom: Issue #68 - 모델 다운로드 진행 상태 수신
+				// Issue #79: 모델 삭제 진행 상태 수신
+				case 'model-delete-progress': {
+					const deleteStatus: ModelDeleteStatus = {
+						model: message.model,
+						status: message.status,
+						message: message.message,
+					};
+					if (deleteStatus.status === 'done') {
+						setModelDeleteStatus(null);
+						// 삭제 완료 시 현재 선택 모델이 삭제된 모델이면 초기화
+						setSelectedModel((prev: string) => {
+							if (prev === deleteStatus.model || prev === `${deleteStatus.model}:latest`) {
+								return '';
+							}
+							return prev;
+						});
+					} else if (deleteStatus.status === 'error') {
+						setModelDeleteStatus(null);
+					} else {
+						setModelDeleteStatus(deleteStatus);
+					}
+					break;
+				}
+
+			// gitbbon custom: Issue #68 - 모델 다운로드 진행 상태 수신
 				case 'model-pull-progress': {
 					const pullStatus: ModelPullStatus = {
 						model: message.model,
@@ -493,6 +546,57 @@ const App: React.FC = () => {
 					</div>
 				</div>
 			)}
+			{/* Issue #79: 모델 관리 모달 */}
+			{modelManageOpen && (
+				<div className="model-manage-modal" onClick={() => setModelManageOpen(false)}>
+					<div className="model-manage-modal-content" onClick={(e) => e.stopPropagation()}>
+						<div className="model-manage-modal-header">
+							<span className="model-manage-modal-title">모델 관리</span>
+							<button className="model-manage-modal-close" onClick={() => setModelManageOpen(false)} aria-label="닫기">✕</button>
+						</div>
+						{freeDiskGB !== Infinity && (
+							<p className="model-manage-disk-info">사용 가능한 디스크: {freeDiskGB.toFixed(1)}GB</p>
+						)}
+						<p className="model-manage-section-label">설치된 모델</p>
+						{recommendedModels.filter(m => m.installed).length === 0 ? (
+							<p className="model-manage-empty">설치된 모델이 없습니다.</p>
+						) : (
+							<ul className="model-manage-list">
+								{recommendedModels.filter(m => m.installed).map((m) => (
+									<li key={m.name} className="model-manage-item">
+										<span className="model-manage-item-name">{m.name}</span>
+										<span className="model-manage-item-size">{m.sizeGB > 0 ? `${m.sizeGB.toFixed(1)}GB` : '-'}</span>
+										<button
+											className="model-manage-delete-btn"
+											onClick={() => handleDeleteModel(m)}
+											disabled={isReceiving || modelDeleteStatus?.status === 'deleting'}
+											title="모델 삭제"
+										>
+											{modelDeleteStatus?.model === m.name && modelDeleteStatus.status === 'deleting' ? '삭제 중...' : '삭제'}
+										</button>
+									</li>
+								))}
+							</ul>
+						)}
+					</div>
+				</div>
+			)}
+			{/* Issue #79: 모델 삭제 확인 다이얼로그 */}
+			{deleteConfirmModel && (
+				<div className="model-download-confirm">
+					<div className="model-download-confirm-content">
+						<p className="model-download-confirm-title">모델 삭제</p>
+						<p className="model-download-confirm-info">
+							<strong>{deleteConfirmModel.name}</strong>를 삭제합니다.<br />
+							다시 사용하려면 {deleteConfirmModel.sizeGB > 0 ? `${deleteConfirmModel.sizeGB.toFixed(1)}GB` : ''}를 재다운로드해야 합니다.
+						</p>
+						<div className="model-download-confirm-actions">
+							<button className="model-download-btn-cancel" onClick={handleCancelDelete}>취소</button>
+							<button className="model-delete-btn-confirm" onClick={handleConfirmDelete}>삭제</button>
+						</div>
+					</div>
+				</div>
+			)}
 			{/* Issue #70: isReceiving를 전달하여 reasoning 스트리밍 중 기본 열림 판별 */}
 			<MessageList messages={messages} isLoading={isSending || isReceiving} isReceiving={isReceiving} onRetry={handleRetry} />
 			<ChatInput
@@ -511,6 +615,7 @@ const App: React.FC = () => {
 				recommendedModels={recommendedModels}
 				modelPullStatus={modelPullStatus}
 				modelCapabilities={modelCapabilities}
+				onOpenModelManage={() => setModelManageOpen(true)}
 			/>
 		</div>
 	);

--- a/extensions/gitbbon-chat/src/webview/components/ChatInput.tsx
+++ b/extensions/gitbbon-chat/src/webview/components/ChatInput.tsx
@@ -21,6 +21,8 @@ interface ChatInputProps {
 	modelPullStatus?: ModelPullStatus | null;
 	// Issue #77: 모델별 capabilities
 	modelCapabilities?: Record<string, ModelCapabilities>;
+	// Issue #79: 모델 관리 모달 열기 콜백
+	onOpenModelManage?: () => void;
 }
 
 // 화살표 전송 아이콘 SVG
@@ -52,7 +54,7 @@ const StopIcon = () => (
 	</svg>
 );
 
-const ChatInput: React.FC<ChatInputProps> = ({ inputValue, setInputValue, isSending, isReceiving, onSubmit, onCancel, inputRef, onCompositionChange, modelType, setModelType, selectedModel, setSelectedModel, ollamaModels, recommendedModels, modelPullStatus, modelCapabilities }) => {
+const ChatInput: React.FC<ChatInputProps> = ({ inputValue, setInputValue, isSending, isReceiving, onSubmit, onCancel, inputRef, onCompositionChange, modelType, setModelType, selectedModel, setSelectedModel, ollamaModels, recommendedModels, modelPullStatus, modelCapabilities, onOpenModelManage }) => {
 	const internalRef = useRef<HTMLTextAreaElement>(null);
 	const textareaRef = inputRef || internalRef;
 	const isLoading = isSending || isReceiving;
@@ -185,6 +187,19 @@ const ChatInput: React.FC<ChatInputProps> = ({ inputValue, setInputValue, isSend
 								<option value="">기본 모델</option>
 							)}
 						</select>
+						{/* Issue #79: 온디바이스 모드에서 모델 관리 버튼 */}
+						{modelType === 'ondevice' && onOpenModelManage && (
+							<button
+								type="button"
+								className="model-manage-btn"
+								onClick={onOpenModelManage}
+								disabled={isLoading}
+								title="모델 관리"
+								aria-label="모델 관리"
+							>
+								⚙
+							</button>
+						)}
 					</div>
 					{isLoading ? (
 						<button

--- a/extensions/gitbbon-chat/src/webview/index.css
+++ b/extensions/gitbbon-chat/src/webview/index.css
@@ -774,6 +774,177 @@ body {
 	50% { opacity: 1; transform: scale(1.1); }
 }
 
+/* Issue #79: 모델 관리 버튼 */
+.model-manage-btn {
+	padding: 2px 6px;
+	border: 1px solid var(--vscode-widget-border);
+	border-radius: 4px;
+	background: transparent;
+	color: var(--vscode-foreground);
+	cursor: pointer;
+	font-size: 0.85em;
+	line-height: 1;
+	opacity: 0.75;
+	transition: opacity 0.15s ease, background-color 0.15s ease;
+}
+
+.model-manage-btn:hover:not(:disabled) {
+	background: var(--vscode-toolbar-hoverBackground, rgba(255, 255, 255, 0.1));
+	opacity: 1;
+}
+
+.model-manage-btn:disabled {
+	opacity: 0.35;
+	cursor: not-allowed;
+}
+
+/* Issue #79: 모델 관리 모달 오버레이 */
+.model-manage-modal {
+	position: fixed;
+	top: 0;
+	left: 0;
+	right: 0;
+	bottom: 0;
+	z-index: 100;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	background: rgba(0, 0, 0, 0.4);
+}
+
+.model-manage-modal-content {
+	background: var(--vscode-editorWidget-background, #252526);
+	border: 1px solid var(--vscode-editorWidget-border, #454545);
+	border-radius: 8px;
+	box-shadow: 0 8px 24px rgba(0, 0, 0, 0.4);
+	padding: 16px;
+	min-width: 280px;
+	max-width: 380px;
+	width: 90%;
+	display: flex;
+	flex-direction: column;
+	gap: 8px;
+}
+
+.model-manage-modal-header {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	margin-bottom: 4px;
+}
+
+.model-manage-modal-title {
+	font-weight: 600;
+	font-size: 13px;
+	color: var(--vscode-foreground);
+}
+
+.model-manage-modal-close {
+	background: transparent;
+	border: none;
+	color: var(--vscode-foreground);
+	cursor: pointer;
+	font-size: 14px;
+	opacity: 0.6;
+	padding: 2px 4px;
+	border-radius: 3px;
+}
+
+.model-manage-modal-close:hover {
+	opacity: 1;
+	background: var(--vscode-toolbar-hoverBackground, rgba(255, 255, 255, 0.1));
+}
+
+.model-manage-disk-info {
+	font-size: 12px;
+	color: var(--vscode-descriptionForeground);
+	margin: 0 0 4px 0;
+}
+
+.model-manage-section-label {
+	font-size: 11px;
+	font-weight: 600;
+	text-transform: uppercase;
+	color: var(--vscode-descriptionForeground);
+	margin: 0 0 4px 0;
+	opacity: 0.7;
+}
+
+.model-manage-empty {
+	font-size: 12px;
+	color: var(--vscode-descriptionForeground);
+	margin: 0;
+}
+
+.model-manage-list {
+	list-style: none;
+	margin: 0;
+	padding: 0;
+	display: flex;
+	flex-direction: column;
+	gap: 4px;
+}
+
+.model-manage-item {
+	display: flex;
+	align-items: center;
+	gap: 8px;
+	padding: 6px 8px;
+	border-radius: 4px;
+	background: var(--vscode-list-hoverBackground, rgba(255, 255, 255, 0.04));
+}
+
+.model-manage-item-name {
+	flex: 1;
+	font-size: 12px;
+	color: var(--vscode-foreground);
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+
+.model-manage-item-size {
+	font-size: 11px;
+	color: var(--vscode-descriptionForeground);
+	white-space: nowrap;
+}
+
+.model-manage-delete-btn {
+	padding: 3px 10px;
+	border: 1px solid var(--vscode-errorForeground, #f44747);
+	border-radius: 4px;
+	background: transparent;
+	color: var(--vscode-errorForeground, #f44747);
+	cursor: pointer;
+	font-size: 11px;
+	white-space: nowrap;
+	transition: background-color 0.15s ease;
+}
+
+.model-manage-delete-btn:hover:not(:disabled) {
+	background: rgba(244, 71, 71, 0.15);
+}
+
+.model-manage-delete-btn:disabled {
+	opacity: 0.4;
+	cursor: not-allowed;
+}
+
+/* Issue #79: 삭제 확인 버튼 (붉은색) */
+.model-delete-btn-confirm {
+	padding: 4px 12px;
+	border: none;
+	border-radius: 4px;
+	cursor: pointer;
+	font-size: 12px;
+	background: var(--vscode-errorForeground, #f44747);
+	color: #fff;
+}
+
+.model-delete-btn-confirm:hover {
+	opacity: 0.85;
+}
+
 /* Issue #70: 추론 내용 영역 */
 .reasoning-accordion-detail {
 	padding: 8px 14px;


### PR DESCRIPTION
## 개요
Closes #79

## 변경사항
- `ollamaService.ts`: `deleteModel()` 추가 (`DELETE /api/delete` 호출)
- `extension.ts`: `delete-ollama-model` 메시지 핸들러 추가 → `model-delete-progress` + `recommended-models` 재전송
- `App.tsx`: 모델 관리 모달 (`modelManageOpen`) + 삭제 확인 다이얼로그 (`deleteConfirmModel`) + `modelDeleteStatus` 상태 추가
- `ChatInput.tsx`: 온디바이스 모드에서 모델 셀렉트 옆 ⚙ 관리 버튼 추가
- `index.css`: 모달·관리 버튼·삭제 버튼 스타일 추가

## 동작
1. 온디바이스 모드에서 모델 셀렉트 옆 ⚙ 버튼 클릭
2. 모달에서 설치된 모델 목록과 디스크 여유 공간 확인
3. [삭제] 클릭 → 확인 다이얼로그 (붉은 삭제 버튼)
4. 확인 후 `DELETE /api/delete` 호출, 완료 후 목록 자동 갱신
5. 채팅 수신 중에는 삭제 버튼 비활성화