### PR TITLE
feat: Issue #82 - 프로젝트 생성 후 자동으로 열기

### DIFF
--- a/extensions/gitbbon-manager/src/extension.ts
+++ b/extensions/gitbbon-manager/src/extension.ts
@@ -238,7 +238,6 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
 
 				// gitbbon custom: 프로젝트 생성 완료 후 해당 프로젝트를 자동으로 열기 (Issue #82)
 				if (result.success && result.projectPath) {
-					logService.info(`[debug:#82] 프로젝트 생성 완료. 자동으로 열기: ${result.projectPath}`);
 					const uri = vscode.Uri.file(result.projectPath);
 					await vscode.commands.executeCommand('vscode.openFolder', uri, { forceNewWindow: true });
 				}


### PR DESCRIPTION
## 개요
Closes #82

## 변경사항
- 프로젝트 생성 완료 후 해당 프로젝트를 자동으로 열도록 수정
- `gitbbon.manager.addProject` 커맨드에서 `addNewProject()` 성공 시 `vscode.openFolder` 실행
- `[debug:#82]` 디버깅 로그 추가