### PR TITLE
fix: Issue #88 - 다크/화이트 테마에서 인라인 코드 텍스트 가시성 개선

### DIFF
--- a/extensions/gitbbon-editor/media/editor.css
+++ b/extensions/gitbbon-editor/media/editor.css
@@ -139,6 +139,7 @@ body {
 
 .milkdown code {
 	background-color: var(--vscode-textCodeBlock-background);
+	color: var(--vscode-editor-foreground);
 	padding: 2px 4px;
 	border-radius: 3px;
 	font-family: 'SF Mono', Monaco, 'Cascadia Code', 'Roboto Mono', Consolas, 'Courier New', monospace;


### PR DESCRIPTION
## 개요
Closes #88

## 변경사항
- 인라인 코드(`code`) 텍스트 색상을 다크/라이트 테마 모두에서 가독성 있게 수정
- `.milkdown code`에 `color: var(--vscode-editor-foreground)` 추가
- milkeditor CSS 조정: `extensions/gitbbon-editor/media/editor.css`