### PR TITLE
feat: Issue #98 - 편집 요청 시 toolChoice required 적용

### DIFF
--- a/extensions/gitbbon-chat/src/services/aiService.ts
+++ b/extensions/gitbbon-chat/src/services/aiService.ts
@@ -306,14 +306,33 @@ export class AIService {
 				};
 
 
+				// gitbbon custom: Issue #98 - 편집 요청 감지 함수
+				const detectEditRequest = (msgs: ModelMessage[]): boolean => {
+					const lastMsg = msgs[msgs.length - 1];
+					const text = typeof lastMsg?.content === 'string'
+						? lastMsg.content
+						: JSON.stringify(lastMsg?.content ?? '');
+					const editKeywords = [
+						'수정', '편집', '고쳐', '변경', '업데이트', '작성해', '만들어', '삭제',
+						'create', 'update', 'edit', 'modify', 'fix', 'delete', 'write', 'add'
+					];
+					return editKeywords.some(kw => text.toLowerCase().includes(kw));
+				};
+
+				// gitbbon custom: Issue #98 - 편집 요청 시 toolChoice required 적용
+				const isEditRequest = detectEditRequest(messages);
+				logService.info(`[debug:#98] detectEditRequest=${isEditRequest}, toolChoice=${isEditRequest ? 'required' : 'auto'}`);
+
 				// Issue #74: tool 미지원 모델 fallback을 위한 헬퍼 함수 (think 옵션도 제어)
 				const callStreamText = (useTools: boolean, useThink: boolean = true) => {
 					const providerOptions = buildProviderOptions(useThink) as any;
+					// gitbbon custom: Issue #98 - 편집 요청 시 toolChoice required 설정으로 텍스트 응답 방지
+					const toolChoice = (useTools && isEditRequest) ? 'required' : 'auto';
 					return streamText({
 						model,
 						system: instructions,
 						messages: messages as ModelMessage[],
-						...(useTools ? { tools, stopWhen: stepCountIs(10) } : {}),
+						...(useTools ? { tools, toolChoice, stopWhen: stepCountIs(10) } : {}),
 						abortSignal: abortController.signal,
 						providerOptions,
 						onStepFinish: (event) => {


### PR DESCRIPTION
## 개요
Closes #98

## 변경사항
- 마지막 메시지 분석으로 편집 요청 감지 함수(`detectEditRequest`) 추가
- 편집 관련 키워드(수정, 편집, create, edit 등) 기반으로 요청 유형 판단
- 편집 요청 시 `toolChoice: 'required'` 설정으로 텍스트 응답 방지
- `[debug:#98]` 로그 추가로 toolChoice 결정 결과 확인 가능