### PR TITLE
feat: Issue #100 - prepareStep 단계별 tool 접근 제어

### DIFF
--- a/extensions/gitbbon-chat/src/services/aiService.ts
+++ b/extensions/gitbbon-chat/src/services/aiService.ts
@@ -306,6 +306,24 @@ export class AIService {
 				};
 
 
+				// Issue #100: prepareStep으로 단계별 tool 접근 제어 (읽기 → 편집 순서 강제)
+				// 읽기 tool을 사용하기 전까지 초반 스텝(stepNumber <= 3)에서 edit_note 비활성화
+				const READ_TOOLS = ['search_in_workspace', 'read_file', 'get_current_file', 'get_selection', 'get_chat_history'] as const;
+				type ReadToolName = typeof READ_TOOLS[number];
+				const ALL_TOOLS = [...READ_TOOLS, 'edit_note'] as const;
+
+				const prepareStepFn = async ({ stepNumber, steps }: { stepNumber: number; steps: Array<{ toolCalls?: Array<{ toolName: string }> }> }) => {
+					const hasReadStep = steps.some(s =>
+						s.toolCalls?.some(t => READ_TOOLS.includes(t.toolName as ReadToolName))
+					);
+					if (!hasReadStep && stepNumber <= 3) {
+						logService.info(`[debug:#100] prepareStep: stepNumber=${stepNumber}, hasReadStep=false → activeTools=${READ_TOOLS.join(', ')}`);
+						return { activeTools: [...READ_TOOLS] };
+					}
+					logService.info(`[debug:#100] prepareStep: stepNumber=${stepNumber}, hasReadStep=${hasReadStep} → activeTools=${ALL_TOOLS.join(', ')}`);
+					return {};
+				};
+
 				// Issue #74: tool 미지원 모델 fallback을 위한 헬퍼 함수 (think 옵션도 제어)
 				const callStreamText = (useTools: boolean, useThink: boolean = true) => {
 					const providerOptions = buildProviderOptions(useThink) as any;
@@ -313,7 +331,7 @@ export class AIService {
 						model,
 						system: instructions,
 						messages: messages as ModelMessage[],
-						...(useTools ? { tools, stopWhen: stepCountIs(10) } : {}),
+						...(useTools ? { tools, stopWhen: stepCountIs(10), prepareStep: prepareStepFn } : {}),
 						abortSignal: abortController.signal,
 						providerOptions,
 						onStepFinish: (event) => {


### PR DESCRIPTION
## 개요
Closes #100

## 변경사항
- `streamText`에 `prepareStep` 옵션 추가로 단계별 tool 접근 제어 구현
- 읽기 tool(`read_file`, `get_current_file` 등) 미사용 && `stepNumber <= 3` 조건에서 `edit_note` 비활성화
- 각 스텝에서 activeTools 결정 과정을 `[debug:#100]` 로그로 기록

## 동작 방식
- 초반 스텝(stepNumber ≤ 3)이고 읽기 tool을 아직 한 번도 사용하지 않은 경우 → `edit_note` 제외한 읽기 전용 tool만 활성화
- 읽기 tool 사용 이력이 있거나 stepNumber > 3이면 → 전체 tool 허용