### PR TITLE
feat: Issue #99 - experimental_context tool 컨텍스트 전달

### DIFF
--- a/extensions/gitbbon-chat/src/services/aiService.ts
+++ b/extensions/gitbbon-chat/src/services/aiService.ts
@@ -209,7 +209,8 @@ export class AIService {
 			}
 		};
 
-		const tools = createEditorTools(messages, emitter);
+		// gitbbon custom: Issue #99 - experimental_context로 tool 컨텍스트 전달 (closure 의존성 제거)
+		const tools = createEditorTools();
 
 		// Resolve model: Ollama returns a LanguageModel object; API backend uses a gateway string ID
 		let model: LanguageModel | string;
@@ -309,6 +310,9 @@ export class AIService {
 				// Issue #74: tool 미지원 모델 fallback을 위한 헬퍼 함수 (think 옵션도 제어)
 				const callStreamText = (useTools: boolean, useThink: boolean = true) => {
 					const providerOptions = buildProviderOptions(useThink) as any;
+					// gitbbon custom: Issue #99 - experimental_context로 tool에 messages/emitter 전달
+					const toolContext = { messages, emitter };
+					logService.info('[debug:#99] streamText experimental_context 설정:', { messageCount: messages.length, hasEmitter: !!emitter });
 					return streamText({
 						model,
 						system: instructions,
@@ -316,6 +320,7 @@ export class AIService {
 						...(useTools ? { tools, stopWhen: stepCountIs(10) } : {}),
 						abortSignal: abortController.signal,
 						providerOptions,
+						experimental_context: toolContext,
 						onStepFinish: (event) => {
 							logService.info('[gitbbon-chat][Agent Step] Step Finished', {
 								text: event.text ? event.text.slice(0, 100) + '...' : undefined,

--- a/extensions/gitbbon-chat/src/tools/editorTools.ts
+++ b/extensions/gitbbon-chat/src/tools/editorTools.ts
@@ -5,6 +5,7 @@ import { ContextService } from '../services/ContextService';
 import { executeSearch } from './implementations/searchTool';
 import { createHistoryTool } from './implementations/historyTool';
 import { type ToolEventEmitter, generateToolId } from '../types';
+import { logService } from '../services/logService';
 
 /**
  * Human-friendly tool labels (not developer names)
@@ -20,6 +21,12 @@ const TOOL_LABELS: Record<string, string> = {
 
 function getToolLabel(toolName: string): string {
 	return TOOL_LABELS[toolName] || toolName;
+}
+
+// gitbbon custom: Issue #99 - experimental_context 타입 정의
+export interface EditorToolContext {
+	messages: ModelMessage[];
+	emitter?: ToolEventEmitter;
 }
 
 /**
@@ -74,13 +81,17 @@ function withProgress<T>(
 
 /**
  * EditorTools Factory
+ * gitbbon custom: Issue #99 - closure 의존성 제거, experimental_context로 messages/emitter 수신
  */
-export function createEditorTools(messages: ModelMessage[], emitter?: ToolEventEmitter) {
+export function createEditorTools() {
 	return {
 		get_selection: tool({
 			description: 'Get selected text from the active editor. Use for "this code", "selected part", etc.',
 			inputSchema: z.object({}),
-			execute: async () => {
+			execute: async (_input, { experimental_context: ctx }) => {
+				// gitbbon custom: Issue #99 - experimental_context에서 emitter 수신
+				const { emitter } = (ctx ?? {}) as EditorToolContext;
+				logService.info('[debug:#99] get_selection tool 실행, hasEmitter:', !!emitter);
 				return withProgress('get_selection', {}, emitter, async () => {
 					const detail = await ContextService.getSelection();
 					if (detail) {
@@ -103,7 +114,10 @@ ${detail.after}
 		get_current_file: tool({
 			description: 'Get the entire content of the active file. Use for "whole file", "structure", etc.',
 			inputSchema: z.object({}),
-			execute: async () => {
+			execute: async (_input, { experimental_context: ctx }) => {
+				// gitbbon custom: Issue #99 - experimental_context에서 emitter 수신
+				const { emitter } = (ctx ?? {}) as EditorToolContext;
+				logService.info('[debug:#99] get_current_file tool 실행, hasEmitter:', !!emitter);
 				return withProgress('get_current_file', {}, emitter, async () => {
 					const content = await ContextService.getActiveFileContent();
 					if (content) return content;
@@ -112,7 +126,20 @@ ${detail.after}
 			},
 		}),
 
-		get_chat_history: createHistoryTool(messages),
+		// gitbbon custom: Issue #99 - get_chat_history는 messages를 experimental_context에서 수신
+		get_chat_history: tool({
+			description: 'Retrieve previous chat history. Use when user refers to "before", "previously", etc.',
+			inputSchema: z.object({
+				count: z.number().min(1).max(50).describe('Number of recent messages to retrieve (1-50)'),
+				query: z.string().optional().describe('Search keyword (optional)'),
+			}),
+			execute: async ({ count, query }, { experimental_context: ctx }) => {
+				const { messages } = (ctx ?? {}) as EditorToolContext;
+				logService.info('[debug:#99] get_chat_history tool 실행, messageCount:', messages?.length ?? 0);
+				// createHistoryTool의 execute 로직을 인라인으로 호출
+				return executeHistoryQuery(messages ?? [], count, query);
+			},
+		}),
 
 		search_in_workspace: tool({
 			description: 'Search for code or notes using natural language (Semantic Search) or keywords (Regex/Ripgrep). Use this for "find code about X" or "where is logic for Y".',
@@ -123,7 +150,10 @@ ${detail.after}
 				context: z.number().min(0).max(500).optional().describe('Characters of context around match (default: 100)'),
 				maxResults: z.number().min(1).max(30).optional().describe('Maximum number of results (default: 5)'),
 			}),
-			execute: async (args) => {
+			execute: async (args, { experimental_context: ctx }) => {
+				// gitbbon custom: Issue #99 - experimental_context에서 emitter 수신
+				const { emitter } = (ctx ?? {}) as EditorToolContext;
+				logService.info('[debug:#99] search_in_workspace tool 실행, query:', args.query);
 				return withProgress('search_in_workspace', { query: args.query }, emitter, () => executeSearch(args));
 			},
 		}),
@@ -133,7 +163,10 @@ ${detail.after}
 			inputSchema: z.object({
 				filePath: z.string().describe('File path with extension (e.g., "notes/chapter 1.md"). Include .md for note files.'),
 			}),
-			execute: async ({ filePath }) => {
+			execute: async ({ filePath }, { experimental_context: ctx }) => {
+				// gitbbon custom: Issue #99 - experimental_context에서 emitter 수신
+				const { emitter } = (ctx ?? {}) as EditorToolContext;
+				logService.info('[debug:#99] read_file tool 실행, filePath:', filePath);
 				return withProgress('read_file', { filePath }, emitter, async () => {
 					try {
 						return await ContextService.readFile(filePath);
@@ -162,8 +195,10 @@ ${detail.after}
 					'Default: "direct", but override to "suggestion" for any .md file.'
 				)
 			}),
-			execute: async ({ action, filePath, title, content, changes, mode }) => {
-
+			execute: async ({ action, filePath, title, content, changes, mode }, { experimental_context: ctx }) => {
+				// gitbbon custom: Issue #99 - experimental_context에서 emitter 수신
+				const { emitter } = (ctx ?? {}) as EditorToolContext;
+				logService.info('[debug:#99] edit_note tool 실행, action:', action, 'filePath:', filePath);
 				return withProgress('edit_note', { action, filePath }, emitter, async () => {
 					try {
 						switch (action) {
@@ -193,4 +228,64 @@ ${detail.after}
 			},
 		}),
 	};
+}
+
+/**
+ * gitbbon custom: Issue #99 - get_chat_history execute 로직 (historyTool closure 대체)
+ * messages를 experimental_context로부터 수신하여 처리
+ */
+function executeHistoryQuery(messages: ModelMessage[], count: number, query?: string): string {
+	if (messages.length === 0) {
+		return "Error: No history available.";
+	}
+
+	const historyPool = messages.length > 5 ? messages.slice(0, -5) : [];
+
+	if (historyPool.length === 0) {
+		return "Error: No older history available (Recent history is already provided).";
+	}
+
+	let filteredMessages = historyPool;
+
+	if (query) {
+		const lowerQuery = query.toLowerCase();
+		filteredMessages = messages.filter(m => {
+			const content = typeof m.content === 'string'
+				? m.content
+				: JSON.stringify(m.content);
+			return content.toLowerCase().includes(lowerQuery);
+		});
+
+		if (filteredMessages.length === 0) {
+			return `Error: No messages found containing "${query}".`;
+		}
+	}
+
+	const selectedMessages = filteredMessages.slice(-count);
+
+	const formatted = selectedMessages.map((m) => {
+		const content = typeof m.content === 'string'
+			? m.content
+			: JSON.stringify(m.content);
+
+		let truncated = content;
+		if (content.length > 500) {
+			if (query) {
+				const lowerContent = content.toLowerCase();
+				const matchIndex = lowerContent.indexOf(query.toLowerCase());
+				if (matchIndex !== -1) {
+					const start = Math.max(0, matchIndex - 250);
+					const end = Math.min(content.length, matchIndex + query.length + 250);
+					truncated = (start > 0 ? '...' : '') + content.slice(start, end) + (end < content.length ? '...' : '');
+				} else {
+					truncated = content.slice(0, 500) + '...';
+				}
+			} else {
+				truncated = content.slice(0, 500) + '...';
+			}
+		}
+		return `[${m.role}]: ${truncated}`;
+	}).join('\n\n');
+
+	return formatted;
 }


### PR DESCRIPTION
## 개요
Closes #99

## 변경사항
- `streamText` 호출 시 `experimental_context`에 `messages`, `emitter` 전달
- `createEditorTools()`에서 closure 파라미터 제거 (`messages`, `emitter` 인자 삭제)
- 각 tool `execute`에서 두 번째 인자 `{ experimental_context: ctx }`로 컨텍스트 수신
- `get_chat_history` tool을 인라인 로직으로 전환하여 `historyTool` closure 의존성 제거
- `[debug:#99]` 로그로 컨텍스트 전달 추적 가능

## 필터 정규식
```
\[debug:#99\]
```