### PR TITLE
feat: TDE 파이프라인 구축 - IContextService 분리 및 테스트 인프라 #111

### DIFF
--- a/extensions/gitbbon-chat/package.json
+++ b/extensions/gitbbon-chat/package.json
@@ -82,7 +82,9 @@
     "watch": "tsc -watch -p ./ & vite build --watch",
     "watch:tsc": "tsc -watch -p ./",
     "watch:webview": "vite build --watch",
-    "build:webview": "vite build"
+    "build:webview": "vite build",
+    "test:tde": "node out/test/runner.js",
+    "test:tde:loop": "bash test/tde-loop.sh"
   },
   "devDependencies": {
     "@types/node": "22.x",

--- a/extensions/gitbbon-chat/src/interfaces/IContextService.ts
+++ b/extensions/gitbbon-chat/src/interfaces/IContextService.ts
@@ -1,0 +1,66 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Gitbbon. All rights reserved.
+ *  Licensed under the MIT License.
+ *--------------------------------------------------------------------------------------------*/
+
+// gitbbon custom: Issue #111 - ContextService 인터페이스 분리 (TDE 파이프라인을 위한 mock 주입 지원)
+
+/**
+ * 에디터 컨텍스트 서비스 인터페이스.
+ * 실제 구현(ContextService)과 테스트용 mock(MockContextService) 모두 이 인터페이스를 구현한다.
+ */
+export interface IContextService {
+	/**
+	 * Gitbbon 커스텀 에디터(Milkdown)가 활성 상태인지 반환
+	 */
+	isGitbbonEditor(): boolean;
+
+	/**
+	 * 현재 활성 파일의 상대 경로를 반환. 없으면 'None'
+	 */
+	getActiveFileName(): string;
+
+	/**
+	 * 활성 에디터에서 선택된 텍스트와 주변 컨텍스트를 반환
+	 */
+	getSelection(): Promise<{ text: string; before: string; after: string } | null>;
+
+	/**
+	 * 활성 파일의 전체 내용을 반환
+	 */
+	getActiveFileContent(): Promise<string | undefined | null>;
+
+	/**
+	 * 커서 주변 라인(±5줄)을 반환
+	 */
+	getCursorContext(): Promise<string | null>;
+
+	/**
+	 * 열린 탭 목록(상대 경로)을 반환
+	 */
+	getOpenTabs(): string[];
+
+	/**
+	 * 특정 파일을 읽어 내용을 반환. 확장자 없으면 .md 자동 추가 시도
+	 */
+	readFile(filePath: string): Promise<string>;
+
+	/**
+	 * 파일에 변경사항을 적용 ('direct' 또는 'suggestion' 모드)
+	 */
+	applySuggestions(
+		filePath: string,
+		changes: { oldText: string; newText: string }[],
+		mode?: 'direct' | 'suggestion'
+	): Promise<void>;
+
+	/**
+	 * 새 노트 파일 생성
+	 */
+	createNote(filePath: string, content: string, title?: string): Promise<string>;
+
+	/**
+	 * 노트 파일 삭제
+	 */
+	deleteNote(filePath: string): Promise<string>;
+}

--- a/extensions/gitbbon-chat/src/services/ContextService.ts
+++ b/extensions/gitbbon-chat/src/services/ContextService.ts
@@ -1,4 +1,6 @@
 import * as vscode from 'vscode';
+// gitbbon custom: Issue #111 - IContextService 인터페이스 re-export (static 클래스 유지, 별도 어댑터 패턴 사용)
+export type { IContextService } from '../interfaces/IContextService';
 
 export class ContextService {
 	private static SELECTION_LIMIT = 1000;
@@ -387,5 +389,46 @@ export class ContextService {
 
 		await vscode.workspace.fs.delete(uri);
 		return `Deleted: ${vscode.workspace.asRelativePath(uri)}`;
+	}
+}
+
+// gitbbon custom: Issue #111 - ContextService static 메서드를 IContextService 인스턴스로 감싸는 어댑터
+// aiService가 IContextService를 주입받을 수 있도록 하면서 기존 동작을 그대로 유지한다
+import type { IContextService } from '../interfaces/IContextService';
+
+export class ContextServiceAdapter implements IContextService {
+	isGitbbonEditor(): boolean {
+		return ContextService.isGitbbonEditor();
+	}
+	getActiveFileName(): string {
+		return ContextService.getActiveFileName();
+	}
+	async getSelection(): Promise<{ text: string; before: string; after: string } | null> {
+		return ContextService.getSelection();
+	}
+	async getActiveFileContent(): Promise<string | null> {
+		return ContextService.getActiveFileContent();
+	}
+	async getCursorContext(): Promise<string | null> {
+		return ContextService.getCursorContext();
+	}
+	getOpenTabs(): string[] {
+		return ContextService.getOpenTabs();
+	}
+	async readFile(filePath: string): Promise<string> {
+		return ContextService.readFile(filePath);
+	}
+	async applySuggestions(
+		filePath: string,
+		changes: { oldText: string; newText: string }[],
+		mode: 'direct' | 'suggestion' = 'direct'
+	): Promise<void> {
+		return ContextService.applySuggestions(filePath, changes, mode);
+	}
+	async createNote(filePath: string, content: string, title?: string): Promise<string> {
+		return ContextService.createNote(filePath, content, title);
+	}
+	async deleteNote(filePath: string): Promise<string> {
+		return ContextService.deleteNote(filePath);
 	}
 }

--- a/extensions/gitbbon-chat/src/services/MockContextService.ts
+++ b/extensions/gitbbon-chat/src/services/MockContextService.ts
@@ -1,0 +1,198 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Gitbbon. All rights reserved.
+ *  Licensed under the MIT License.
+ *--------------------------------------------------------------------------------------------*/
+
+// gitbbon custom: Issue #111 - vscode API 없이 동작하는 MockContextService (TDE 테스트 파이프라인 전용)
+
+import * as fs from 'fs';
+import * as path from 'path';
+import type { IContextService } from '../interfaces/IContextService';
+
+/**
+ * 시나리오별로 주입되는 mock 컨텍스트 데이터
+ */
+export interface MockContextData {
+	/** 현재 활성 파일 이름 (상대 경로) */
+	activeFileName?: string;
+	/** 현재 활성 파일 전체 내용 */
+	activeFileContent?: string | null;
+	/** 선택 텍스트와 주변 컨텍스트 */
+	selection?: { text: string; before: string; after: string } | null;
+	/** 열린 탭 목록 */
+	openTabs?: string[];
+	/** 파일 경로 → 파일 내용 맵 (readFile 응답용) */
+	files?: Record<string, string>;
+	/** applySuggestions 호출 기록 (검증용) */
+	appliedChanges?: Array<{ filePath: string; changes: { oldText: string; newText: string }[]; mode: string }>;
+	/** createNote 호출 기록 (검증용) */
+	createdNotes?: Array<{ filePath: string; content: string; title?: string }>;
+	/** deleteNote 호출 기록 (검증용) */
+	deletedNotes?: string[];
+}
+
+/**
+ * vscode API 없이 동작하는 ContextService mock 구현체.
+ * TDE 테스트 러너에서 aiService에 주입해 실제 LLM 호출은 그대로 유지하면서
+ * 파일시스템/에디터 의존성을 제거한다.
+ */
+export class MockContextService implements IContextService {
+	private data: MockContextData;
+
+	constructor(data: MockContextData = {}) {
+		this.data = {
+			activeFileName: data.activeFileName ?? 'None',
+			activeFileContent: data.activeFileContent ?? undefined,
+			selection: data.selection !== undefined ? data.selection : null,
+			openTabs: data.openTabs ?? [],
+			files: data.files ?? {},
+			appliedChanges: data.appliedChanges ?? [],
+			createdNotes: data.createdNotes ?? [],
+			deletedNotes: data.deletedNotes ?? [],
+		};
+		console.log('[debug:#111] MockContextService 초기화:', {
+			activeFileName: this.data.activeFileName,
+			fileCount: Object.keys(this.data.files ?? {}).length,
+		});
+	}
+
+	isGitbbonEditor(): boolean {
+		// mock 환경에서는 Milkdown 에디터가 없으므로 항상 false
+		return false;
+	}
+
+	getActiveFileName(): string {
+		const name = this.data.activeFileName ?? 'None';
+		console.log('[debug:#111] MockContextService.getActiveFileName:', name);
+		return name;
+	}
+
+	async getSelection(): Promise<{ text: string; before: string; after: string } | null> {
+		const sel = this.data.selection ?? null;
+		console.log('[debug:#111] MockContextService.getSelection:', sel ? `"${sel.text.slice(0, 50)}..."` : 'null');
+		return sel;
+	}
+
+	async getActiveFileContent(): Promise<string | undefined | null> {
+		const content = this.data.activeFileContent ?? null;
+		console.log('[debug:#111] MockContextService.getActiveFileContent:', content ? `${content.length}자` : 'null');
+		return content;
+	}
+
+	async getCursorContext(): Promise<string | null> {
+		// 선택된 텍스트가 없을 때 커서 주변 컨텍스트를 반환
+		// mock에서는 activeFileContent의 앞 10줄을 반환
+		if (!this.data.activeFileContent) return null;
+		const lines = this.data.activeFileContent.split('\n').slice(0, 10).join('\n');
+		console.log('[debug:#111] MockContextService.getCursorContext:', `${lines.length}자`);
+		return lines || null;
+	}
+
+	getOpenTabs(): string[] {
+		const tabs = this.data.openTabs ?? [];
+		console.log('[debug:#111] MockContextService.getOpenTabs:', tabs);
+		return tabs;
+	}
+
+	async readFile(filePath: string): Promise<string> {
+		console.log('[debug:#111] MockContextService.readFile:', filePath);
+
+		// 1. mock 파일 맵에서 먼저 조회
+		const files = this.data.files ?? {};
+		if (files[filePath]) {
+			return files[filePath];
+		}
+
+		// 2. .md 확장자 자동 추가 시도
+		if (!/\.[a-zA-Z0-9]+$/.test(filePath)) {
+			const mdPath = filePath + '.md';
+			if (files[mdPath]) {
+				console.log(`[debug:#111] MockContextService.readFile: "${filePath}" → "${mdPath}" (.md 자동 추가)`);
+				return files[mdPath];
+			}
+		}
+
+		// 3. 실제 파일시스템에서 시도 (테스트 fixture 파일 지원)
+		try {
+			const content = fs.readFileSync(filePath, 'utf-8');
+			return content;
+		} catch {
+			// 무시
+		}
+
+		throw new Error(`File not found in mock: "${filePath}"`);
+	}
+
+	async applySuggestions(
+		filePath: string,
+		changes: { oldText: string; newText: string }[],
+		mode: 'direct' | 'suggestion' = 'direct'
+	): Promise<void> {
+		console.log('[debug:#111] MockContextService.applySuggestions:', { filePath, changes, mode });
+
+		// 변경 기록 추적 (검증용)
+		(this.data.appliedChanges ??= []).push({ filePath, changes, mode });
+
+		// mock 파일 맵이 있으면 실제로 변경 적용 (검증 가능하도록)
+		const files = this.data.files ?? {};
+		if (files[filePath] !== undefined) {
+			let content = files[filePath];
+			for (const { oldText, newText } of changes) {
+				if (!content.includes(oldText)) {
+					throw new Error(`oldText not found in mock file "${filePath}": "${oldText.slice(0, 50)}"`);
+				}
+				content = content.replace(oldText, newText);
+			}
+			files[filePath] = content;
+		}
+	}
+
+	async createNote(filePath: string, content: string, title?: string): Promise<string> {
+		console.log('[debug:#111] MockContextService.createNote:', { filePath, title });
+
+		const normalizedPath = /\.[a-zA-Z0-9]+$/.test(filePath) ? filePath : filePath + '.md';
+		const files = this.data.files ?? {};
+
+		if (files[normalizedPath] !== undefined) {
+			return `Error: File already exists: ${normalizedPath}. Use action "update" to modify it.`;
+		}
+
+		let finalContent = content;
+		if (title) {
+			finalContent = `---\ntitle: ${title}\n---\n${content}`;
+		}
+
+		files[normalizedPath] = finalContent;
+		(this.data.createdNotes ??= []).push({ filePath: normalizedPath, content: finalContent, title });
+
+		return `Created: ${normalizedPath}`;
+	}
+
+	async deleteNote(filePath: string): Promise<string> {
+		console.log('[debug:#111] MockContextService.deleteNote:', filePath);
+
+		const files = this.data.files ?? {};
+		if (files[filePath] !== undefined) {
+			delete files[filePath];
+			(this.data.deletedNotes ??= []).push(filePath);
+			return `Deleted: ${filePath}`;
+		}
+
+		// .md 자동 추가 시도
+		const mdPath = /\.[a-zA-Z0-9]+$/.test(filePath) ? filePath : filePath + '.md';
+		if (files[mdPath] !== undefined) {
+			delete files[mdPath];
+			(this.data.deletedNotes ??= []).push(mdPath);
+			return `Deleted: ${mdPath}`;
+		}
+
+		throw new Error(`File not found: "${filePath}"`);
+	}
+
+	/**
+	 * 테스트 검증용 스냅샷 반환
+	 */
+	getSnapshot(): Readonly<MockContextData> {
+		return { ...this.data };
+	}
+}

--- a/extensions/gitbbon-chat/src/services/aiService.ts
+++ b/extensions/gitbbon-chat/src/services/aiService.ts
@@ -2,7 +2,9 @@ import * as vscode from 'vscode';
 import { streamText, stepCountIs, type ModelMessage, type LanguageModel, type ToolSet, type TypedToolCall, type TypedToolResult } from 'ai';
 import { ollama } from 'ollama-ai-provider-v2';
 import { createEditorTools } from '../tools/editorTools';
-import { ContextService } from './ContextService';
+import { ContextService, ContextServiceAdapter } from './ContextService';
+// gitbbon custom: Issue #111 - IContextService 주입 지원 (TDE mock 주입 가능)
+import type { IContextService } from '../interfaces/IContextService';
 import { SYSTEM_PROMPT } from '../constants/prompts';
 import { type StreamEvent, type ToolStartEvent, type ToolEndEvent, generateToolId } from '../types';
 import { logService } from './logService';
@@ -54,8 +56,12 @@ export class AIService {
 	private apiKey: string | undefined;
 	private initialized = false;
 	private currentAbortController: AbortController | null = null;
+	// gitbbon custom: Issue #111 - IContextService 주입 (기본값은 ContextServiceAdapter로 기존 동작 유지)
+	private contextService: IContextService;
 
-	constructor(private readonly secrets: vscode.SecretStorage) { }
+	constructor(private readonly secrets: vscode.SecretStorage, contextService?: IContextService) {
+		this.contextService = contextService ?? new ContextServiceAdapter();
+	}
 
 	public async getBackend(): Promise<'api' | 'ollama'> {
 		const stored = await this.secrets.get('CHAT_BACKEND');
@@ -210,7 +216,8 @@ export class AIService {
 		};
 
 		// gitbbon custom: Issue #99 - experimental_context로 tool 컨텍스트 전달 (closure 의존성 제거)
-		const tools = createEditorTools();
+		// gitbbon custom: Issue #111 - 주입된 contextService를 editorTools에 전달
+		const tools = createEditorTools(this.contextService);
 
 		// Resolve model: Ollama returns a LanguageModel object; API backend uses a gateway string ID
 		let model: LanguageModel | string;
@@ -223,10 +230,11 @@ export class AIService {
 			model = 'openai/o4-mini';
 		}
 
+		// gitbbon custom: Issue #111 - ContextService 직접 참조 대신 주입된 contextService 사용
 		// Context collection
-		const activeFile = ContextService.getActiveFileName();
+		const activeFile = this.contextService.getActiveFileName();
 		let selectionPreview = 'None';
-		const selectionDetail = await ContextService.getSelection();
+		const selectionDetail = await this.contextService.getSelection();
 		const SELECTION_LIMIT = 1000;
 
 		if (selectionDetail) {
@@ -238,12 +246,12 @@ export class AIService {
 
 		let cursorContext = 'None';
 		if (!selectionDetail) {
-			const context = await ContextService.getCursorContext();
+			const context = await this.contextService.getCursorContext();
 			if (context) cursorContext = context;
 		}
 
 		const olderMessageCount = Math.max(0, messages.length - 5);
-		const openTabs = ContextService.getOpenTabs();
+		const openTabs = this.contextService.getOpenTabs();
 		const contextParts: string[] = ['[Current Environment Context]'];
 
 		const workspaceFolders = vscode.workspace.workspaceFolders;
@@ -349,7 +357,8 @@ export class AIService {
 					// gitbbon custom: Issue #98 - 편집 요청 시 toolChoice required 설정으로 텍스트 응답 방지
 					const toolChoice = (useTools && isEditRequest) ? 'required' : 'auto';
 					// gitbbon custom: Issue #99 - experimental_context로 tool에 messages/emitter 전달
-					const toolContext = { messages, emitter };
+					// gitbbon custom: Issue #111 - contextService도 experimental_context에 포함
+				const toolContext = { messages, emitter, contextService: this.contextService };
 					return streamText({
 						model,
 						system: instructions,

--- a/extensions/gitbbon-chat/src/tools/editorTools.ts
+++ b/extensions/gitbbon-chat/src/tools/editorTools.ts
@@ -2,6 +2,9 @@ import { tool } from 'ai';
 import { z } from 'zod';
 import type { ModelMessage } from 'ai';
 import { ContextService } from '../services/ContextService';
+// gitbbon custom: Issue #111 - IContextService 주입 지원 (TDE mock 주입 가능)
+import type { IContextService } from '../interfaces/IContextService';
+import { ContextServiceAdapter } from '../services/ContextService';
 import { executeSearch } from './implementations/searchTool';
 import { createHistoryTool } from './implementations/historyTool';
 import { type ToolEventEmitter, generateToolId } from '../types';
@@ -24,9 +27,11 @@ function getToolLabel(toolName: string): string {
 }
 
 // gitbbon custom: Issue #99 - experimental_context 타입 정의
+// gitbbon custom: Issue #111 - contextService 필드 추가 (mock 주입 지원)
 export interface EditorToolContext {
 	messages: ModelMessage[];
 	emitter?: ToolEventEmitter;
+	contextService?: IContextService;
 }
 
 /**
@@ -82,17 +87,22 @@ function withProgress<T>(
 /**
  * EditorTools Factory
  * gitbbon custom: Issue #99 - closure 의존성 제거, experimental_context로 messages/emitter 수신
+ * gitbbon custom: Issue #111 - contextService 주입 지원 (기본값: ContextServiceAdapter)
  */
-export function createEditorTools() {
+export function createEditorTools(defaultContextService?: IContextService) {
+	// 기본 contextService (주입 없으면 ContextServiceAdapter 사용)
+	const defaultCtxSvc: IContextService = defaultContextService ?? new ContextServiceAdapter();
 	return {
 		get_selection: tool({
 			description: 'Get selected text from the active editor. Use for "this code", "selected part", etc.',
 			inputSchema: z.object({}),
 			execute: async (_input, { experimental_context: ctx }) => {
 				// gitbbon custom: Issue #99 - experimental_context에서 emitter 수신
-				const { emitter } = (ctx ?? {}) as EditorToolContext;
+				// gitbbon custom: Issue #111 - contextService 주입 지원
+				const { emitter, contextService } = (ctx ?? {}) as EditorToolContext;
+				const ctxSvc = contextService ?? defaultCtxSvc;
 				return withProgress('get_selection', {}, emitter, async () => {
-					const detail = await ContextService.getSelection();
+					const detail = await ctxSvc.getSelection();
 					if (detail) {
 						return `
 [Context Before]
@@ -115,9 +125,11 @@ ${detail.after}
 			inputSchema: z.object({}),
 			execute: async (_input, { experimental_context: ctx }) => {
 				// gitbbon custom: Issue #99 - experimental_context에서 emitter 수신
-				const { emitter } = (ctx ?? {}) as EditorToolContext;
+				// gitbbon custom: Issue #111 - contextService 주입 지원
+				const { emitter, contextService } = (ctx ?? {}) as EditorToolContext;
+				const ctxSvc = contextService ?? defaultCtxSvc;
 				return withProgress('get_current_file', {}, emitter, async () => {
-					const content = await ContextService.getActiveFileContent();
+					const content = await ctxSvc.getActiveFileContent();
 					if (content) return content;
 					return "No active editor found. Do NOT retry — use read_file with a specific file path instead.";
 				});
@@ -149,6 +161,7 @@ ${detail.after}
 			}),
 			execute: async (args, { experimental_context: ctx }) => {
 				// gitbbon custom: Issue #99 - experimental_context에서 emitter 수신
+				// gitbbon custom: Issue #111 - contextService 주입 지원 (search는 vscode 의존이므로 emitter만 사용)
 				const { emitter } = (ctx ?? {}) as EditorToolContext;
 				return withProgress('search_in_workspace', { query: args.query }, emitter, () => executeSearch(args));
 			},
@@ -161,10 +174,12 @@ ${detail.after}
 			}),
 			execute: async ({ filePath }, { experimental_context: ctx }) => {
 				// gitbbon custom: Issue #99 - experimental_context에서 emitter 수신
-				const { emitter } = (ctx ?? {}) as EditorToolContext;
+				// gitbbon custom: Issue #111 - contextService 주입 지원
+				const { emitter, contextService } = (ctx ?? {}) as EditorToolContext;
+				const ctxSvc = contextService ?? defaultCtxSvc;
 				return withProgress('read_file', { filePath }, emitter, async () => {
 					try {
-						return await ContextService.readFile(filePath);
+						return await ctxSvc.readFile(filePath);
 					} catch (e) {
 						return `Error: Failed to read file (${filePath}). ${e}`;
 					}
@@ -192,22 +207,24 @@ ${detail.after}
 			}),
 			execute: async ({ action, filePath, title, content, changes, mode }, { experimental_context: ctx }) => {
 				// gitbbon custom: Issue #99 - experimental_context에서 emitter 수신
-				const { emitter } = (ctx ?? {}) as EditorToolContext;
+				// gitbbon custom: Issue #111 - contextService 주입 지원
+				const { emitter, contextService } = (ctx ?? {}) as EditorToolContext;
+				const ctxSvc = contextService ?? defaultCtxSvc;
 				return withProgress('edit_note', { action, filePath }, emitter, async () => {
 					try {
 						switch (action) {
 							case 'create':
 								if (!content) return 'Error: content required.';
-								return await ContextService.createNote(filePath, content, title);
+								return await ctxSvc.createNote(filePath, content, title);
 							case 'update':
 								if (!changes?.length) return 'Error: changes required.';
-								await ContextService.applySuggestions(filePath, changes, mode || 'direct');
+								await ctxSvc.applySuggestions(filePath, changes, mode || 'direct');
 								if ((mode || 'direct') === 'suggestion') {
 									return `Suggestion applied to ${filePath}. Changes are shown in the UI pending user approval — do NOT read or re-edit this file.`;
 								}
 								return `Updated: ${filePath}`;
 							case 'delete':
-								return await ContextService.deleteNote(filePath);
+								return await ctxSvc.deleteNote(filePath);
 							default:
 								return `Error: Unknown action ${action}`;
 						}
@@ -215,7 +232,8 @@ ${detail.after}
 						const msg = e instanceof Error ? e.message : String(e);
 						if (action === 'update') {
 							try {
-								const fileContent = await ContextService.readFile(filePath);
+								// gitbbon custom: Issue #111 - contextService 주입 지원
+								const fileContent = await ctxSvc.readFile(filePath);
 								return `Error: ${msg}\n\n[Current Content]\n${fileContent}`;
 							} catch { /* ignore */ }
 						}

--- a/extensions/gitbbon-chat/test/evaluator.ts
+++ b/extensions/gitbbon-chat/test/evaluator.ts
@@ -1,0 +1,149 @@
+// gitbbon custom: Issue #111 - TDE 평가 로직 (Judge 평가기)
+
+import type { ScenarioResult, TestScenario } from './runner';
+
+/**
+ * 시나리오 실행 결과를 기대값과 비교해 pass/fail 판정
+ */
+export interface EvaluationResult {
+	scenarioId: string;
+	passed: boolean;
+	failures: string[];
+	warnings: string[];
+}
+
+/**
+ * 단일 시나리오 결과를 평가
+ */
+export function evaluateScenario(scenario: TestScenario, result: ScenarioResult): EvaluationResult {
+	const failures: string[] = [];
+	const warnings: string[] = [];
+	const { expected } = scenario;
+
+	console.log(`[debug:#111] 평가 시작: ${scenario.id}`);
+
+	// 1. 반드시 호출되어야 할 툴 확인 (mustBeCalled)
+	const calledTools = result.toolCallNames ?? [];
+	if (expected.toolsMustBeCalled) {
+		for (const toolName of expected.toolsMustBeCalled) {
+			if (!calledTools.includes(toolName)) {
+				failures.push(`툴 "${toolName}"이 호출되지 않았습니다 (필수). 실제 호출: [${calledTools.join(', ')}]`);
+			}
+		}
+	}
+
+	// 2. 하나 이상 호출되어야 할 툴 확인 (shouldBeCalled - OR 조건)
+	if (expected.toolsShouldBeCalled && expected.toolsShouldBeCalled.length > 0) {
+		const anyMatch = expected.toolsShouldBeCalled.some(t => calledTools.includes(t));
+		if (!anyMatch) {
+			failures.push(
+				`다음 툴 중 하나는 호출되어야 합니다: [${expected.toolsShouldBeCalled.join(', ')}]. ` +
+				`실제 호출: [${calledTools.join(', ')}]`
+			);
+		}
+	}
+
+	// 3. 호출되면 안 되는 툴 확인
+	if (expected.toolsShouldNotBeCalled) {
+		for (const toolName of expected.toolsShouldNotBeCalled) {
+			if (calledTools.includes(toolName)) {
+				failures.push(`툴 "${toolName}"이 호출되었으나 호출되면 안 됩니다`);
+			}
+		}
+	}
+
+	// 4. 파일 변경 여부 확인
+	if (expected.shouldModifyFiles !== undefined) {
+		const didModify = (result.fileModifications ?? []).length > 0;
+		if (expected.shouldModifyFiles && !didModify) {
+			failures.push('파일 수정이 발생해야 하지만 발생하지 않았습니다');
+		} else if (!expected.shouldModifyFiles && didModify) {
+			failures.push(`파일 수정이 발생하면 안 되지만 발생했습니다: [${result.fileModifications?.join(', ')}]`);
+		}
+	}
+
+	// 5. 텍스트 응답 여부 확인
+	if (expected.shouldHaveTextResponse !== undefined) {
+		const hasText = (result.textContent ?? '').trim().length > 0;
+		if (expected.shouldHaveTextResponse && !hasText) {
+			failures.push('텍스트 응답이 있어야 하지만 없습니다');
+		} else if (!expected.shouldHaveTextResponse && hasText) {
+			warnings.push(`텍스트 응답이 없어야 하지만 있습니다: "${result.textContent?.slice(0, 100)}..."`);
+		}
+	}
+
+	// 6. 오류 발생 여부 확인
+	if (result.error) {
+		failures.push(`시나리오 실행 중 오류 발생: ${result.error}`);
+	}
+
+	const passed = failures.length === 0;
+	console.log(`[debug:#111] 평가 완료: ${scenario.id} → ${passed ? 'PASS' : 'FAIL'}`);
+	if (failures.length > 0) {
+		console.log(`[debug:#111] 실패 원인:`, failures);
+	}
+
+	return {
+		scenarioId: scenario.id,
+		passed,
+		failures,
+		warnings,
+	};
+}
+
+/**
+ * 여러 시나리오 결과를 일괄 평가
+ */
+export function evaluateAll(
+	scenarios: TestScenario[],
+	results: ScenarioResult[]
+): EvaluationResult[] {
+	const resultMap = new Map(results.map(r => [r.scenarioId, r]));
+	return scenarios.map(scenario => {
+		const result = resultMap.get(scenario.id);
+		if (!result) {
+			return {
+				scenarioId: scenario.id,
+				passed: false,
+				failures: ['시나리오 결과를 찾을 수 없습니다'],
+				warnings: [],
+			};
+		}
+		return evaluateScenario(scenario, result);
+	});
+}
+
+/**
+ * 평가 결과 요약 출력
+ */
+export function printSummary(evaluations: EvaluationResult[]): void {
+	const total = evaluations.length;
+	const passed = evaluations.filter(e => e.passed).length;
+	const failed = total - passed;
+
+	console.log('\n' + '='.repeat(60));
+	console.log(`TDE 평가 결과: ${passed}/${total} 통과`);
+	console.log('='.repeat(60));
+
+	for (const eval_ of evaluations) {
+		const icon = eval_.passed ? '✅' : '❌';
+		console.log(`${icon} ${eval_.scenarioId}`);
+		if (!eval_.passed) {
+			for (const failure of eval_.failures) {
+				console.log(`   └─ ${failure}`);
+			}
+		}
+		if (eval_.warnings.length > 0) {
+			for (const warning of eval_.warnings) {
+				console.log(`   ⚠️  ${warning}`);
+			}
+		}
+	}
+
+	console.log('='.repeat(60));
+	if (failed > 0) {
+		console.log(`❌ ${failed}개 시나리오 실패`);
+	} else {
+		console.log('✅ 모든 시나리오 통과');
+	}
+}

--- a/extensions/gitbbon-chat/test/runner.ts
+++ b/extensions/gitbbon-chat/test/runner.ts
@@ -1,0 +1,316 @@
+#!/usr/bin/env node
+// gitbbon custom: Issue #111 - TDE 테스트 러너 (MockContextService 주입 + aiService.streamAgentChat() 직접 호출)
+
+/**
+ * 사용법:
+ *   node out/test/runner.js
+ *   node out/test/runner.js --scenario file-summary
+ *   node out/test/runner.js --tag smoke --repeat 3
+ *   node out/test/runner.js --scenario file-summary --repeat 2 --tag smoke
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+import type { ModelMessage } from 'ai';
+import { MockContextService, type MockContextData } from '../src/services/MockContextService';
+import { evaluateAll, printSummary } from './evaluator';
+import { fileSummaryScenario } from './scenarios/file-summary.scenario';
+import { editNoteScenario } from './scenarios/edit-note.scenario';
+import { textOnlyResponseScenario } from './scenarios/text-only-response.scenario';
+
+// ─────────────────────────────────────────────
+// 타입 정의
+// ─────────────────────────────────────────────
+
+/** 시나리오 기대값 */
+export interface ScenarioExpected {
+	/** 이 툴들 중 하나 이상 호출 (OR 조건) */
+	toolsShouldBeCalled?: string[];
+	/** 이 툴들이 모두 반드시 호출 (AND 조건) */
+	toolsMustBeCalled?: string[];
+	/** 호출되면 안 되는 툴 */
+	toolsShouldNotBeCalled?: string[];
+	/** 파일 변경 발생 여부 */
+	shouldModifyFiles?: boolean;
+	/** 텍스트 응답 여부 */
+	shouldHaveTextResponse?: boolean;
+}
+
+/** 테스트 시나리오 정의 */
+export interface TestScenario {
+	id: string;
+	description: string;
+	tags: string[];
+	mockContext: MockContextData & { activeFileContent?: string | null };
+	input: string;
+	expected: ScenarioExpected;
+}
+
+/** 시나리오 실행 결과 */
+export interface ScenarioResult {
+	scenarioId: string;
+	/** 호출된 툴 이름 목록 */
+	toolCallNames: string[];
+	/** 수정된 파일 목록 */
+	fileModifications: string[];
+	/** 수집된 텍스트 응답 전체 */
+	textContent: string;
+	/** 오류 메시지 (있을 경우) */
+	error?: string;
+	/** 실행 시간(ms) */
+	durationMs: number;
+	/** raw 스트림 이벤트 */
+	events: unknown[];
+}
+
+// ─────────────────────────────────────────────
+// 시나리오 목록
+// ─────────────────────────────────────────────
+
+const ALL_SCENARIOS: TestScenario[] = [
+	fileSummaryScenario,
+	editNoteScenario,
+	textOnlyResponseScenario,
+];
+
+// ─────────────────────────────────────────────
+// AIService를 vscode 없이 실행하기 위한 최소 stub
+// ─────────────────────────────────────────────
+
+/**
+ * vscode.SecretStorage 최소 stub
+ * TDE 환경에서는 환경변수 AI_GATEWAY_API_KEY만 사용
+ */
+const mockSecrets = {
+	async get(key: string): Promise<string | undefined> {
+		if (key === 'AI_GATEWAY_API_KEY') {
+			return process.env.AI_GATEWAY_API_KEY;
+		}
+		if (key === 'CHAT_BACKEND') {
+			return process.env.TDE_BACKEND ?? 'api';
+		}
+		return undefined;
+	},
+	async store(key: string, value: string): Promise<void> {
+		console.log(`[debug:#111] mockSecrets.store: ${key}`);
+	},
+	async delete(key: string): Promise<void> { },
+	onDidChange: { event: () => ({ dispose: () => {} }) },
+} as unknown as import('vscode').SecretStorage;
+
+// ─────────────────────────────────────────────
+// 단일 시나리오 실행
+// ─────────────────────────────────────────────
+
+async function runScenario(scenario: TestScenario): Promise<ScenarioResult> {
+	console.log(`\n[debug:#111] 시나리오 실행: ${scenario.id} - "${scenario.description}"`);
+
+	const startTime = Date.now();
+	const events: unknown[] = [];
+	const toolCallNames: string[] = [];
+	let textContent = '';
+	let error: string | undefined;
+
+	// MockContextService 생성 (시나리오별 컨텍스트 주입)
+	const mockCtxService = new MockContextService(scenario.mockContext);
+
+	try {
+		// API 키 확인 (없으면 graceful 실패)
+		const apiKey = process.env.AI_GATEWAY_API_KEY;
+		if (!apiKey) {
+			console.warn('[debug:#111] AI_GATEWAY_API_KEY 환경변수가 없습니다. 시나리오를 건너뜁니다.');
+			return {
+				scenarioId: scenario.id,
+				toolCallNames: [],
+				fileModifications: [],
+				textContent: '',
+				error: 'API_KEY_MISSING: AI_GATEWAY_API_KEY 환경변수가 설정되지 않았습니다',
+				durationMs: Date.now() - startTime,
+				events: [],
+			};
+		}
+
+		// AIService를 동적으로 import (vscode 없이 실행 가능하도록 조건부 로드)
+		const { AIService } = await import('../src/services/aiService.js');
+		const aiService = new AIService(mockSecrets, mockCtxService);
+
+		const messages: ModelMessage[] = [
+			{ role: 'user', content: scenario.input }
+		];
+
+		// streamAgentChat 실행 및 이벤트 수집
+		for await (const event of aiService.streamAgentChat(messages)) {
+			events.push(event);
+			const e = event as { type: string; toolName?: string; content?: string };
+
+			if (e.type === 'tool-start' && e.toolName && e.toolName !== 'Thinking...') {
+				// 툴 이름을 TOOL_LABELS 역방향으로 추적
+				// editorTools의 TOOL_LABELS에 정의된 실제 툴 이름으로 매핑
+				const toolName = resolveToolName(e.toolName);
+				if (toolName) {
+					toolCallNames.push(toolName);
+					console.log(`[debug:#111] 툴 호출: ${toolName} (label: ${e.toolName})`);
+				}
+			} else if (e.type === 'text' && e.content) {
+				textContent += e.content;
+			}
+		}
+	} catch (err: unknown) {
+		const msg = err instanceof Error ? err.message : String(err);
+		console.error(`[debug:#111] 시나리오 실행 오류:`, msg);
+		error = msg;
+	}
+
+	// 파일 수정 여부 확인 (appliedChanges + createdNotes + deletedNotes)
+	const snapshot = mockCtxService.getSnapshot();
+	const fileModifications: string[] = [
+		...(snapshot.appliedChanges ?? []).map(c => c.filePath),
+		...(snapshot.createdNotes ?? []).map(n => n.filePath),
+		...(snapshot.deletedNotes ?? []),
+	];
+
+	const durationMs = Date.now() - startTime;
+	console.log(`[debug:#111] 시나리오 완료: ${scenario.id} (${durationMs}ms)`);
+	console.log(`[debug:#111] 호출된 툴: [${toolCallNames.join(', ')}]`);
+	console.log(`[debug:#111] 수정된 파일: [${fileModifications.join(', ')}]`);
+	console.log(`[debug:#111] 텍스트 응답 길이: ${textContent.length}자`);
+
+	return {
+		scenarioId: scenario.id,
+		toolCallNames,
+		fileModifications,
+		textContent,
+		error,
+		durationMs,
+		events,
+	};
+}
+
+/**
+ * tool-start 이벤트의 toolName(label)을 실제 tool ID로 변환
+ */
+function resolveToolName(label: string): string | null {
+	const LABEL_TO_TOOL: Record<string, string> = {
+		'Reading selection': 'get_selection',
+		'Reading current file': 'get_current_file',
+		'Loading chat history': 'get_chat_history',
+		'Searching files': 'search_in_workspace',
+		'Reading file': 'read_file',
+		'Editing note': 'edit_note',
+	};
+	return LABEL_TO_TOOL[label] ?? null;
+}
+
+// ─────────────────────────────────────────────
+// CLI 파라미터 파싱
+// ─────────────────────────────────────────────
+
+function parseArgs(): { scenarioId?: string; tags?: string[]; repeat: number } {
+	const args = process.argv.slice(2);
+	let scenarioId: string | undefined;
+	let tags: string[] | undefined;
+	let repeat = 1;
+
+	for (let i = 0; i < args.length; i++) {
+		if (args[i] === '--scenario' && args[i + 1]) {
+			scenarioId = args[++i];
+		} else if (args[i] === '--tag' && args[i + 1]) {
+			tags = args[++i].split(',');
+		} else if (args[i] === '--repeat' && args[i + 1]) {
+			repeat = parseInt(args[++i], 10) || 1;
+		}
+	}
+
+	return { scenarioId, tags, repeat };
+}
+
+// ─────────────────────────────────────────────
+// 결과 저장
+// ─────────────────────────────────────────────
+
+function saveResults(results: ScenarioResult[], evaluations: ReturnType<typeof evaluateAll>): void {
+	const reportsDir = path.join(__dirname, 'reports');
+	if (!fs.existsSync(reportsDir)) {
+		fs.mkdirSync(reportsDir, { recursive: true });
+	}
+
+	const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
+	const filePath = path.join(reportsDir, `result-${timestamp}.json`);
+
+	const report = {
+		timestamp: new Date().toISOString(),
+		summary: {
+			total: evaluations.length,
+			passed: evaluations.filter(e => e.passed).length,
+			failed: evaluations.filter(e => !e.passed).length,
+		},
+		evaluations,
+		results: results.map(r => ({
+			...r,
+			// 이벤트는 너무 크므로 개수만 기록
+			eventCount: r.events.length,
+			events: undefined,
+		})),
+	};
+
+	fs.writeFileSync(filePath, JSON.stringify(report, null, 2), 'utf-8');
+	console.log(`\n[debug:#111] 결과 저장: ${filePath}`);
+}
+
+// ─────────────────────────────────────────────
+// 메인 실행
+// ─────────────────────────────────────────────
+
+async function main(): Promise<void> {
+	const { scenarioId, tags, repeat } = parseArgs();
+
+	// 실행할 시나리오 필터링
+	let scenarios = ALL_SCENARIOS;
+	if (scenarioId) {
+		scenarios = scenarios.filter(s => s.id === scenarioId);
+		if (scenarios.length === 0) {
+			console.error(`시나리오를 찾을 수 없습니다: ${scenarioId}`);
+			process.exit(1);
+		}
+	}
+	if (tags && tags.length > 0) {
+		scenarios = scenarios.filter(s => tags.some(tag => s.tags.includes(tag)));
+		if (scenarios.length === 0) {
+			console.error(`태그와 일치하는 시나리오가 없습니다: ${tags.join(', ')}`);
+			process.exit(1);
+		}
+	}
+
+	console.log(`\n${'='.repeat(60)}`);
+	console.log(`TDE 러너 시작: ${scenarios.length}개 시나리오 × ${repeat}회 반복`);
+	console.log('='.repeat(60));
+
+	const allResults: ScenarioResult[] = [];
+
+	// 각 시나리오 실행 (repeat 횟수만큼 반복)
+	for (let run = 1; run <= repeat; run++) {
+		if (repeat > 1) {
+			console.log(`\n--- 실행 ${run}/${repeat} ---`);
+		}
+		for (const scenario of scenarios) {
+			const result = await runScenario(scenario);
+			allResults.push(result);
+		}
+	}
+
+	// 평가
+	const evaluations = evaluateAll(scenarios, allResults);
+	printSummary(evaluations);
+
+	// 결과 저장
+	saveResults(allResults, evaluations);
+
+	// 실패한 시나리오가 있으면 exit code 1
+	const hasFailed = evaluations.some(e => !e.passed);
+	process.exit(hasFailed ? 1 : 0);
+}
+
+main().catch(err => {
+	console.error('[debug:#111] Runner 오류:', err);
+	process.exit(1);
+});

--- a/extensions/gitbbon-chat/test/scenarios/edit-note.scenario.ts
+++ b/extensions/gitbbon-chat/test/scenarios/edit-note.scenario.ts
@@ -1,0 +1,41 @@
+// gitbbon custom: Issue #111 - 파일 편집 시나리오 (TDE 파이프라인)
+
+import type { TestScenario } from '../runner';
+
+/**
+ * 파일 편집 요청 시나리오.
+ * 사용자가 현재 파일의 특정 내용을 수정 요청하면
+ * LLM이 edit_note 툴을 호출해야 한다.
+ */
+export const editNoteScenario: TestScenario = {
+	id: 'edit-note',
+	description: '파일 편집 요청 시 edit_note 툴을 호출해야 한다',
+	tags: ['smoke', 'write'],
+
+	// mock 컨텍스트: 편집 대상 파일
+	mockContext: {
+		activeFileName: 'notes/todo.md',
+		activeFileContent: `# 할 일 목록
+
+- [ ] 장보기
+- [ ] 운동하기
+- [ ] 책 읽기`,
+		openTabs: ['notes/todo.md'],
+		files: {
+			'notes/todo.md': `# 할 일 목록\n\n- [ ] 장보기\n- [ ] 운동하기\n- [ ] 책 읽기`,
+		},
+	},
+
+	// 입력 메시지
+	input: '장보기를 완료 처리해줘',
+
+	// 기대값
+	expected: {
+		// edit_note 툴이 반드시 호출되어야 함
+		toolsMustBeCalled: ['edit_note'],
+		// 파일 변경이 발생해야 함
+		shouldModifyFiles: true,
+		// 텍스트 응답이 있어야 함
+		shouldHaveTextResponse: true,
+	},
+};

--- a/extensions/gitbbon-chat/test/scenarios/file-summary.scenario.ts
+++ b/extensions/gitbbon-chat/test/scenarios/file-summary.scenario.ts
@@ -1,0 +1,49 @@
+// gitbbon custom: Issue #111 - 파일 요약 시나리오 (TDE 파이프라인)
+
+import type { TestScenario } from '../runner';
+
+/**
+ * 파일 요약 요청 시나리오.
+ * 사용자가 현재 열린 파일의 요약을 요청하면
+ * LLM이 get_current_file 또는 read_file 툴을 호출해야 한다.
+ */
+export const fileSummaryScenario: TestScenario = {
+	id: 'file-summary',
+	description: '현재 파일 요약 요청 시 파일 읽기 툴을 호출해야 한다',
+	tags: ['smoke', 'read'],
+
+	// mock 컨텍스트: 현재 열린 파일 정보
+	mockContext: {
+		activeFileName: 'notes/chapter-1.md',
+		activeFileContent: `# 1장: 인공지능의 역사
+
+인공지능(AI)은 1956년 다트머스 회의에서 공식적으로 시작되었습니다.
+초기에는 규칙 기반 시스템이 주류였으나, 머신러닝의 등장으로 패러다임이 바뀌었습니다.
+딥러닝의 발전으로 현재는 LLM 시대를 맞이하고 있습니다.
+
+## 주요 이정표
+- 1956: 다트머스 회의 (AI 용어 최초 사용)
+- 1997: Deep Blue가 체스 챔피언 카스파로프를 이김
+- 2012: AlexNet으로 딥러닝 혁명 시작
+- 2022: ChatGPT 출시로 LLM 대중화`,
+		openTabs: ['notes/chapter-1.md', 'notes/chapter-2.md'],
+		files: {
+			'notes/chapter-1.md': `# 1장: 인공지능의 역사\n\n인공지능(AI)은 1956년 다트머스 회의에서 공식적으로 시작되었습니다.`,
+		},
+	},
+
+	// 입력 메시지
+	input: '현재 파일을 요약해줘',
+
+	// 기대값
+	expected: {
+		// 이 툴들 중 하나 이상 호출되어야 함
+		toolsShouldBeCalled: ['get_current_file', 'read_file'],
+		// 이 툴은 호출되면 안 됨
+		toolsShouldNotBeCalled: ['edit_note'],
+		// 파일 변경이 발생하면 안 됨
+		shouldModifyFiles: false,
+		// 텍스트 응답이 있어야 함
+		shouldHaveTextResponse: true,
+	},
+};

--- a/extensions/gitbbon-chat/test/scenarios/text-only-response.scenario.ts
+++ b/extensions/gitbbon-chat/test/scenarios/text-only-response.scenario.ts
@@ -1,0 +1,35 @@
+// gitbbon custom: Issue #111 - 텍스트 전용 응답 시나리오 (TDE 파이프라인)
+
+import type { TestScenario } from '../runner';
+
+/**
+ * 텍스트만 응답해야 할 시나리오.
+ * 파일과 무관한 일반적인 질문을 하면
+ * LLM이 파일 편집 툴을 호출하지 않고 텍스트만 응답해야 한다.
+ */
+export const textOnlyResponseScenario: TestScenario = {
+	id: 'text-only-response',
+	description: '일반 지식 질문에는 툴 호출 없이 텍스트만 응답해야 한다',
+	tags: ['smoke', 'text'],
+
+	// mock 컨텍스트: 에디터 없음
+	mockContext: {
+		activeFileName: 'None',
+		activeFileContent: undefined,
+		openTabs: [],
+		files: {},
+	},
+
+	// 입력 메시지 (파일과 무관한 일반 질문)
+	input: '마크다운이 무엇인가요? 간단히 설명해주세요.',
+
+	// 기대값
+	expected: {
+		// 이 툴들은 호출되면 안 됨
+		toolsShouldNotBeCalled: ['edit_note', 'get_current_file', 'read_file'],
+		// 파일 변경이 발생하면 안 됨
+		shouldModifyFiles: false,
+		// 텍스트 응답이 있어야 함
+		shouldHaveTextResponse: true,
+	},
+};

--- a/extensions/gitbbon-chat/test/tde-loop.sh
+++ b/extensions/gitbbon-chat/test/tde-loop.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+# gitbbon custom: Issue #111 - TDE 루프 실행 스크립트
+# LLM이 테스트를 실행하고, 실패 원인을 분석해 코드를 수정하고, 다시 테스트하는 루프
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+echo "=========================================="
+echo "TDE (테스트 주도 진화) 루프 시작"
+echo "프로젝트: ${PROJECT_DIR}"
+echo "=========================================="
+
+# claude -p를 사용해 비대화형으로 전체 루프 실행
+# LLM이 테스트 실행 → 실패 분석 → 코드 수정 → 재실행을 자율적으로 반복
+claude -p "
+다음 절차를 순서대로 실행해주세요:
+
+1. 현재 디렉토리: ${PROJECT_DIR}
+2. 먼저 \`npm run compile\`로 TypeScript를 컴파일하세요
+3. \`node out/test/runner.js\`를 실행해 테스트 결과를 확인하세요
+4. 실패한 시나리오가 있으면:
+   a. test/reports/ 디렉토리의 최신 result-*.json 파일을 읽어 실패 원인을 분석하세요
+   b. 실패 원인에 따라 관련 소스 파일을 수정하세요 (주석은 한국어로, 수정 주석은 '// gitbbon custom: TDE 수정 - <이유>' 형식)
+   c. 다시 컴파일하고 테스트를 실행하세요
+   d. 모든 테스트가 통과할 때까지 최대 3회 반복하세요
+5. 최종 결과를 요약해 출력하세요
+
+주의사항:
+- aiService의 실제 LLM 호출은 수정하지 마세요 (테스트의 핵심)
+- MockContextService나 시나리오 파일은 수정 가능합니다
+- 테스트 실패 시 시나리오 기대값을 완화하는 방식으로 수정하지 마세요
+" \
+  --allowedTools "Bash,Read,Edit,Write" \
+  --permission-mode acceptEdits
+
+echo ""
+echo "TDE 루프 완료"

--- a/extensions/gitbbon-chat/tsconfig.json
+++ b/extensions/gitbbon-chat/tsconfig.json
@@ -4,7 +4,7 @@
     "target": "ES2022",
     "lib": ["ES2022"],
     "sourceMap": true,
-    "rootDir": "src",
+    "rootDir": ".",
     "outDir": "out",
     "strict": true,
     "esModuleInterop": true,
@@ -12,6 +12,6 @@
     "forceConsistentCasingInFileNames": true,
     "moduleResolution": "Node16"
   },
-  "include": ["src/**/*"],
+  "include": ["src/**/*", "test/**/*"],
   "exclude": ["node_modules", "src/webview/**/*"]
 }


### PR DESCRIPTION
## Summary

- `IContextService` 인터페이스 정의 및 `ContextServiceAdapter` 구현으로 `ContextService` static 클래스를 주입 가능하게 분리
- `MockContextService` 구현 — vscode API 없이 순수 Node.js로 동작하며 시나리오별 컨텍스트 데이터 주입 지원
- `AIService` 생성자에 `IContextService` 주입 지원 추가 (기본값: `ContextServiceAdapter`로 기존 동작 유지)
- 테스트 인프라 구축: `runner.ts`, `evaluator.ts`, 시나리오 3종 (`file-summary`, `edit-note`, `text-only-response`)
- `tde-loop.sh`: `claude -p`로 테스트→분석→코드수정→재테스트 루프를 비대화형으로 실행

## Test plan

- [ ] `npm run compile` 통과 확인
- [ ] `AI_GATEWAY_API_KEY` 환경변수 설정 후 `npm run test:tde` 실행
- [ ] `--scenario file-summary` 옵션으로 단일 시나리오 실행 확인
- [ ] `--tag smoke --repeat 2` 옵션 확인
- [ ] API 키 없을 때 graceful 실패 (exit code 1, 명확한 오류 메시지) 확인
- [ ] `test/reports/result-*.json` 파일 생성 확인

Closes #111

🤖 Generated with [Claude Code](https://claude.com/claude-code)