### PR TITLE
feat: Issue #115 - file explore 아이콘 숨기기

### DIFF
--- a/src/vs/workbench/contrib/files/browser/views/explorerViewer.ts
+++ b/src/vs/workbench/contrib/files/browser/views/explorerViewer.ts
@@ -1022,13 +1022,15 @@ export class FilesRenderer implements ICompressibleTreeRenderer<ExplorerItem, Fu
 		const themeIsUnhappyWithNesting = theme.hasFileIcons && (theme.hidesExplorerArrows || !theme.hasFolderIcons);
 		const realignNestedChildren = stat.nestedParent && themeIsUnhappyWithNesting;
 		templateData.contribs.forEach(c => c.setResource(stat.resource));
+		// gitbbon custom: 파일 탐색기 아이템 아이콘 숨기기 (#115)
 		templateData.label.setResource({ resource: stat.resource, name: label }, {
 			fileKind: stat.isRoot ? FileKind.ROOT_FOLDER : stat.isDirectory ? FileKind.FOLDER : FileKind.FILE,
 			extraClasses: realignNestedChildren ? [...extraClasses, 'align-nest-icon-with-parent-icon'] : extraClasses,
 			fileDecorations: this.config.explorer.decorations,
 			matches: createMatches(filterData),
 			separator: this.labelService.getSeparator(stat.resource.scheme, stat.resource.authority),
-			domId
+			domId,
+			hideIcon: true
 		});
 
 		const highlightResults = stat.isDirectory ? this.highlightTree.get(stat) : 0;


### PR DESCRIPTION
## 개요
Closes #115

## 변경사항
- 파일 탐색기에서 파일 앞에 표시되는 아이콘을 숨김
- `explorerViewer.ts`의 `renderStat()` 메서드에서 `setResource()` 호출 시 `hideIcon: true` 옵션 추가