### PR TITLE
feat: Issue #116 - README.md를 README로 표시

### DIFF
--- a/src/vs/workbench/contrib/files/common/explorerModel.ts
+++ b/src/vs/workbench/contrib/files/common/explorerModel.ts
@@ -168,6 +168,14 @@ export class ExplorerItem {
 					this._title = newTitle;
 					this._onDidChange?.(this);
 				}
+			} else {
+				// gitbbon custom: frontmatter title이 없는 경우 .md 확장자를 제거한 파일명을 기본 title로 사용
+				const nameWithoutExt = this.name.replace(/\.md$/i, '');
+				ExplorerItem.titleCache.set(this.resource, nameWithoutExt);
+				if (this._title !== nameWithoutExt) {
+					this._title = nameWithoutExt;
+					this._onDidChange?.(this);
+				}
 			}
 		} catch (e) {
 			// Ignore errors (file might not exist or be readable)


### PR DESCRIPTION
## 개요
Closes #116

## 변경사항
- 파일 탐색기에서 frontmatter title이 없는 .md 파일은 확장자를 제거한 파일명을 표시
- README.md → README로 표시됨