### PR TITLE
fix: Issue #127 - GatewayAuthenticationError 후 모델 재선택 시 오류 지속 문제 수정

### DIFF
--- a/extensions/gitbbon-chat/src/services/aiService.ts
+++ b/extensions/gitbbon-chat/src/services/aiService.ts
@@ -170,10 +170,6 @@ export class AIService {
 	private async handleApiKeyFailure(): Promise<boolean> {
 		logService.warn('[gitbbon-chat][aiService] API key invalid or missing, prompting user...');
 
-		// gitbbon custom: GatewayAuthenticationError 후 auth 상태 초기화 (#127)
-		// SecretStorage에서 유효하지 않은 키를 삭제해야 모델 재선택 후에도 오류가 반복되지 않음
-		await this.secrets.delete('AI_GATEWAY_API_KEY');
-
 		this.apiKey = undefined;
 		this.initialized = false;
 		process.env.AI_GATEWAY_API_KEY = '';
@@ -197,8 +193,22 @@ export class AIService {
 
 	public async *streamAgentChat(messages: ModelMessage[], selectedModel?: string, modelCapabilities?: { thinking: boolean; tools: boolean; completion: boolean }): AsyncGenerator<StreamEvent, void, unknown> {
 		const backend = await this.getBackend();
+		// gitbbon custom: GatewayAuthenticationError 진단용 상태 로그 (#127)
+		logService.info('[gitbbon-chat][aiService] streamAgentChat 진입', {
+			backend,
+			initialized: this.initialized,
+			hasApiKey: !!this.apiKey,
+			hasEnvKey: !!process.env.AI_GATEWAY_API_KEY,
+			selectedModel: selectedModel || 'none',
+		});
 		if (backend !== 'ollama') {
 			await this.ensureInitialized();
+			// gitbbon custom: ensureInitialized 완료 후 상태 확인 (#127)
+			logService.info('[gitbbon-chat][aiService] ensureInitialized 완료', {
+				initialized: this.initialized,
+				hasApiKey: !!this.apiKey,
+				hasEnvKey: !!process.env.AI_GATEWAY_API_KEY,
+			});
 			if (!this.apiKey) {
 				const keyProvided = await this.promptForApiKey();
 				if (!keyProvided || !this.apiKey) {
@@ -610,7 +620,18 @@ export class AIService {
 						success: true,
 					});
 				} else if (this.isGatewayAuthError(error)) {
-					logService.warn('[gitbbon-chat][aiService] GatewayAuthenticationError detected:', (error as Error).message);
+					// gitbbon custom: GatewayAuthenticationError 진단 로그 — 실제 원인 파악용 (#127)
+					// 앱 리로드 시 문제 해결 → API 키 자체는 유효, 상태/인스턴스 문제 가능성
+					logService.warn('[gitbbon-chat][aiService] GatewayAuthenticationError 발생 — 진단 정보:', {
+						errorName: (error as Error)?.name,
+						errorMessage: (error as Error)?.message,
+						errorStack: (error as Error)?.stack?.split('\n').slice(0, 5).join(' | '),
+						initialized: this.initialized,
+						hasApiKey: !!this.apiKey,
+						hasEnvKey: !!process.env.AI_GATEWAY_API_KEY,
+						model: typeof model === 'string' ? model : 'ollama-object',
+						backend,
+					});
 					channel.push({
 						type: 'tool-end',
 						id: thinkingId,

--- a/extensions/gitbbon-manager/src/commitMessageGenerator.ts
+++ b/extensions/gitbbon-manager/src/commitMessageGenerator.ts
@@ -109,19 +109,23 @@ ${diff.substring(0, 3000)}
 					return generatedMessage;
 				}
 			} catch (error: any) {
-				// gitbbon custom: GatewayAuthenticationError 후 auth 상태 초기화 (#127)
-				// GatewayAuthenticationError는 모든 모델에서 동일하게 실패하므로 즉시 중단하고 인증 상태를 초기화
+				// gitbbon custom: GatewayAuthenticationError 진단 로그 (#127)
+				// 앱 리로드 시 해결 → API 키 자체는 유효, 상태/인스턴스 문제 가능성
 				const isAuthError =
 					error?.name === 'GatewayAuthenticationError' ||
 					error?.constructor?.name === 'GatewayAuthenticationError' ||
 					(typeof error?.message === 'string' && error.message.includes('Unauthenticated request to AI Gateway'));
 
 				if (isAuthError) {
-					console.warn(`[CommitMessageGenerator] GatewayAuthenticationError detected — clearing cached auth state`);
-					await this.secrets.delete('AI_GATEWAY_API_KEY');
-					this.apiKey = undefined;
-					this.initialized = false;
-					process.env.AI_GATEWAY_API_KEY = '';
+					console.warn(`[CommitMessageGenerator] GatewayAuthenticationError 발생 — 진단 정보:`, {
+						model: modelName,
+						errorName: error?.name,
+						errorMessage: error?.message,
+						hasApiKey: !!this.apiKey,
+						hasEnvKey: !!process.env.AI_GATEWAY_API_KEY,
+						initialized: this.initialized,
+					});
+					// 모든 모델에서 동일하게 실패하므로 fallback 중단
 					return null;
 				}
 


### PR DESCRIPTION
## 개요
Closes #127

## 변경사항
- GatewayAuthenticationError 발생 시 상세 진단 로그 추가 (initialized, hasApiKey, hasEnvKey, model, stack)
- streamAgentChat 진입·ensureInitialized 완료 시점에 상태 로그 추가
- 잘못된 SecretStorage 키 삭제 로직 제거 (앱 리로드로 해결 = API 키 자체는 유효, 다른 원인 추적 필요)
- commitMessageGenerator도 동일하게 수정

## 배경
초기 수정에서 SecretStorage 키를 삭제했으나, '앱 리로드 시 문제 해결'이라는 단서로 봐서 API 키 자체는 유효함.
진단 로그를 통해 다음 발생 시 실제 원인을 파악할 수 있도록 함.