### PR TITLE
perf: TypeScript Mangler 비활성화로 빌드 시간 단축 (#143)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -104,6 +104,8 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           # 표준 러너 메모리에 맞춤 (macOS 14GB, Linux/Windows 7GB)
           NODE_OPTIONS: ${{ runner.os == 'macOS' && '--max-old-space-size=12288' || '--max-old-space-size=6144' }}
+          # gitbbon custom: CI 빌드에서 TypeScript Mangling 비활성화하여 빌드 시간 단축 (#143)
+          VSCODE_SKIP_MANGLE: 1
 
       # gitbbon custom: macOS 코드 서명 및 공증 (Developer ID Application 인증서 사용)
       - name: Code sign and notarize (macOS)

--- a/build/lib/compilation.ts
+++ b/build/lib/compilation.ts
@@ -130,8 +130,13 @@ export function compileTask(src: string, out: string, build: boolean, options: {
 		}
 
 		// mangle: TypeScript to TypeScript
+		// gitbbon custom: VSCODE_SKIP_MANGLE 환경변수로 Mangling 비활성화 옵션 추가 (빌드 시간 단축용)
+		const skipMangle = Boolean(process.env['VSCODE_SKIP_MANGLE']);
+		if (skipMangle) {
+			console.log('[debug:#143] VSCODE_SKIP_MANGLE=1 감지: Mangling 단계를 건너뜁니다.');
+		}
 		let mangleStream = es.through();
-		if (build && !options.disableMangle) {
+		if (build && !options.disableMangle && !skipMangle) {
 			let ts2tsMangler: Mangler | undefined = new Mangler(compile.projectPath, (...data) => fancyLog(ansiColors.blue('[mangler]'), ...data), { mangleExports: true, manglePrivateFields: true });
 			const newContentsByFileName = ts2tsMangler.computeNewFileContents(new Set(['saveState']));
 			mangleStream = es.through(async function write(data: File & { sourceMap?: RawSourceMap }) {


### PR DESCRIPTION
## Summary
- `build/lib/compilation.ts`에 `VSCODE_SKIP_MANGLE` 환경변수 체크 로직 추가
- `VSCODE_SKIP_MANGLE=1` 설정 시 TypeScript Mangling 단계를 건너뜀
- CI(`release.yml`)에 `VSCODE_SKIP_MANGLE=1` 환경변수 설정 추가

## 변경 내용
- `compileTask()` 함수 내 Mangling 조건에 `!skipMangle` 체크 추가 (기존 `disableMangle` 옵션과 병행)
- `[debug:#143]` 로그로 Mangling 건너뜀 여부 출력
- CI 빌드에서 Mangling 제거로 컴파일 시간 단축

## 예상 효과
- 빌드 시간 수분 단축
- 디버깅 시 심볼 이름 보존으로 가독성 향상

Closes #143

## Test plan
- [ ] `VSCODE_SKIP_MANGLE=1 npm run gulp vscode-darwin-arm64-min` 실행 후 Mangling 건너뜀 로그 확인
- [ ] `VSCODE_SKIP_MANGLE` 미설정 시 기존처럼 Mangling 수행되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)