### PR TITLE
perf: Issue #144 - 릴리즈 빌드에 esbuild 트랜스파일 적용

### DIFF
--- a/build/gulpfile.compile.ts
+++ b/build/gulpfile.compile.ts
@@ -14,7 +14,8 @@ function makeCompileBuildTask(disableMangle: boolean) {
 		util.rimraf('out-build'),
 		date.writeISODate('out-build'),
 		compilation.compileApiProposalNamesTask,
-		compilation.compileTask('src', 'out-build', true, { disableMangle })
+		// gitbbon custom: esbuild 트랜스파일 활성화로 릴리즈 빌드 속도 단축 (Issue #144)
+		compilation.compileTask('src', 'out-build', true, { disableMangle, esbuild: true })
 	);
 }
 

--- a/build/lib/compilation.ts
+++ b/build/lib/compilation.ts
@@ -114,7 +114,7 @@ export function transpileTask(src: string, out: string, esbuild?: boolean): task
 	return task;
 }
 
-export function compileTask(src: string, out: string, build: boolean, options: { disableMangle?: boolean; preserveEnglish?: boolean } = {}): task.StreamTask {
+export function compileTask(src: string, out: string, build: boolean, options: { disableMangle?: boolean; preserveEnglish?: boolean; esbuild?: boolean } = {}): task.StreamTask {
 
 	const task = () => {
 
@@ -122,7 +122,12 @@ export function compileTask(src: string, out: string, build: boolean, options: {
 			throw new Error('compilation requires 4GB of RAM');
 		}
 
-		const compile = createCompile(src, { build, emitError: true, transpileOnly: false, preserveEnglish: !!options.preserveEnglish });
+		// gitbbon custom: esbuild 옵션으로 트랜스파일러 선택 분기 (빌드 속도 최적화)
+		const transpileOnly: boolean | { esbuild: boolean } = options.esbuild ? { esbuild: true } : false;
+		if (options.esbuild) {
+			console.log('[debug:#144] esbuild 트랜스파일 모드로 compile 실행');
+		}
+		const compile = createCompile(src, { build, emitError: true, transpileOnly, preserveEnglish: !!options.preserveEnglish });
 		const srcPipe = gulp.src(`${src}/**`, { base: `${src}` });
 		const generator = new MonacoGenerator(false);
 		if (src === 'src') {

--- a/build/lib/tsb/transpiler.ts
+++ b/build/lib/tsb/transpiler.ts
@@ -374,11 +374,25 @@ export class ESBuildTranspiler implements ITranspiler {
 			const outBase = this._cmdLine.options.outDir ?? file.base;
 			const outPath = this._outputFileNames.getOutputFileName(file.path);
 
-			this.onOutfile!(new Vinyl({
+			// gitbbon custom: NLS 파이프라인이 f.sourceMap 속성을 필요로 하므로 inline 소스맵을 분리
+			const mapMatch = result.code.match(/\/\/# sourceMappingURL=data:application\/json;base64,(.+)$/m);
+			const codeWithoutMap = result.code.replace(/\n?\/\/# sourceMappingURL=.*$/m, '');
+			const outFile = new Vinyl({
 				path: outPath,
 				base: outBase,
-				contents: Buffer.from(result.code),
-			}));
+				contents: Buffer.from(codeWithoutMap),
+			});
+			if (mapMatch) {
+				try {
+					(outFile as any).sourceMap = JSON.parse(Buffer.from(mapMatch[1], 'base64').toString());
+					console.log(`[debug:#144] sourceMap 분리 성공: ${file.path}`);
+				} catch (e) {
+					console.error(`[debug:#144] sourceMap 파싱 실패: ${file.path}`, e);
+				}
+			} else {
+				console.warn(`[debug:#144] sourceMap 미발견: ${file.path}`);
+			}
+			this.onOutfile!(outFile);
 
 			this._logFn('Transpile', `esbuild took ${Date.now() - t1}ms for ${file.path}`);
 


### PR DESCRIPTION
## 개요
Closes #144

## 변경사항
- `build/lib/tsb/transpiler.ts`: ESBuildTranspiler에서 inline 소스맵을 Vinyl.sourceMap 속성으로 분리 (NLS 파이프라인 호환)
- `build/lib/compilation.ts`: compileTask에 `esbuild?: boolean` 옵션 추가 및 esbuild 모드 진입 로그
- `build/gulpfile.compile.ts`: 릴리즈 빌드에서 esbuild 트랜스파일 활성화

## 기반 PR
PR #146 (issue-143 브랜치) 위에 작업. Mangling 비활성화가 이미 적용된 상태.

## 검증 방법
```bash
VSCODE_SKIP_MANGLE=1 npm run gulp compile-build-without-mangling
```
NLS 에러 없이 out-build 생성되면 성공.