### PR TITLE
debug: Issue #148 - auto-commit 진단 로그 추가

### DIFF
--- a/extensions/gitbbon-editor/src/editorProvider.ts
+++ b/extensions/gitbbon-editor/src/editorProvider.ts
@@ -534,9 +534,11 @@ export class GitbbonEditorProvider implements vscode.CustomTextEditorProvider {
 		const resetTimers = () => {
 			// 1. Auto Save Timer Reset
 			if (autoSaveTimer) {
+				logService.info(`[debug:#148] autoSaveTimer cancelled at: ${Date.now()}`);
 				clearTimeout(autoSaveTimer);
 			}
 			autoSaveTimer = setTimeout(async () => {
+				logService.info(`[debug:#148] autoSaveTimer fired at: ${Date.now()}, isDirty: ${document.isDirty}, isUntitled: ${document.isUntitled}`);
 				// Untitled 문서는 자동 저장하지 않음 (저장 대화상자 방지)
 				if (document.isUntitled) {
 					return;
@@ -548,9 +550,11 @@ export class GitbbonEditorProvider implements vscode.CustomTextEditorProvider {
 					logService.error('Auto save failed:', error);
 				}
 			}, AUTO_SAVE_DELAY_MS);
+			logService.info(`[debug:#148] autoSaveTimer started at: ${Date.now()}, delay: ${AUTO_SAVE_DELAY_MS}ms`);
 
 			// 2. Auto Commit Timer Reset (MVP: 3s fixed)
 			if (autoCommitTimer) {
+				logService.info(`[debug:#148] autoCommitTimer cancelled at: ${Date.now()}`);
 				clearTimeout(autoCommitTimer);
 			}
 
@@ -558,6 +562,7 @@ export class GitbbonEditorProvider implements vscode.CustomTextEditorProvider {
 			const delay = 500;
 
 			autoCommitTimer = setTimeout(async () => {
+				logService.info(`[debug:#148] autoCommitTimer fired at: ${Date.now()}, isDirty: ${document.isDirty}, isUntitled: ${document.isUntitled}`);
 				// Untitled 문서는 자동 커밋하지 않음
 				if (document.isUntitled) {
 					return;
@@ -567,7 +572,9 @@ export class GitbbonEditorProvider implements vscode.CustomTextEditorProvider {
 					await document.save();
 
 					// 자동 커밋 실행
+					logService.info(`[debug:#148] Executing autoCommit command at: ${Date.now()}, isDirty: ${document.isDirty}`);
 					const result = await vscode.commands.executeCommand('gitbbon.manager.autoCommit') as { success: boolean; message: string } | undefined;
+					logService.info(`[debug:#148] autoCommit result: success=${result?.success}, message=${result?.message}`);
 					if (result?.success) {
 						// 커밋 성공 시 기준 텍스트 갱신
 						lastCommittedText = document.getText();
@@ -585,6 +592,7 @@ export class GitbbonEditorProvider implements vscode.CustomTextEditorProvider {
 					logService.error('Auto commit failed:', error);
 				}
 			}, delay);
+			logService.info(`[debug:#148] autoCommitTimer started at: ${Date.now()}, delay: ${delay}ms`);
 		};
 
 		let isWebviewUpdating = false;
@@ -599,11 +607,13 @@ export class GitbbonEditorProvider implements vscode.CustomTextEditorProvider {
 					case 'update':
 						const fullText = FrontmatterParser.stringify(message.frontmatter, message.content);
 						if (fullText === lastWebviewText) {
+							logService.info(`[debug:#148] update early-return: lastWebviewText === fullText at ${Date.now()}, length: ${fullText.length}`);
 							return; // 내용이 같으면 무시
 						}
 						// gitbbon custom: 저장 후 실제 문서 내용으로 업데이트 (메타데이터 포함)
 						// 아직 저장 전이므로 임시로 fullText 저장
 
+						logService.info(`[debug:#148] isWebviewUpdating entering at: ${Date.now()}`);
 						isWebviewUpdating = true;
 						try {
 							await this.updateDocument(document, message.frontmatter, message.content);
@@ -611,6 +621,7 @@ export class GitbbonEditorProvider implements vscode.CustomTextEditorProvider {
 							lastWebviewText = document.getText();
 						} finally {
 							isWebviewUpdating = false;
+							logService.info(`[debug:#148] isWebviewUpdating exiting at: ${Date.now()}`);
 						}
 						// 문서 업데이트 후 타이머 리셋 (Auto Save & Auto Commit)
 						resetTimers();

--- a/extensions/gitbbon-manager/src/projectManager.ts
+++ b/extensions/gitbbon-manager/src/projectManager.ts
@@ -735,10 +735,12 @@ Refer to **AGENTS.md** for the agent instructions for this project.
 	 */
 	private async hasChanges(cwd: string): Promise<boolean> {
 		try {
+			// [debug:#148] 이 비교는 디스크 파일 vs HEAD (git status --porcelain)
 			const status = await this.execGit(['status', '--porcelain'], cwd);
 			const hasChanges = status.length > 0;
+			const lines = status.split('\n').filter(line => line.trim());
+			logService.info(`[debug:#148] hasChanges result: ${hasChanges} | disk status lines (first 3): ${JSON.stringify(lines.slice(0, 3))}`);
 			if (hasChanges) {
-				const lines = status.split('\n').filter(line => line.trim());
 				logService.info(`[gitbbon-manager][projectManager] Found ${lines.length} changed files`);
 			} else {
 				logService.info(`[gitbbon-manager][projectManager] No changes found`);
@@ -840,6 +842,7 @@ Refer to **AGENTS.md** for the agent instructions for this project.
 
 		// 임시 인덱스 파일 경로 생성 (사용자 인덱스 보호)
 		const tempIndexFile = path.join(cwd, '.git', `index-autosave-${Date.now()}`);
+		logService.info(`[debug:#148] tempIndexFile path: ${tempIndexFile}`);
 		const env = { 'GIT_INDEX_FILE': tempIndexFile };
 
 		try {
@@ -855,7 +858,9 @@ Refer to **AGENTS.md** for the agent instructions for this project.
 
 			// 1. Stage all changes (into TEMP index)
 			logService.info('[gitbbon-manager][projectManager] Staging all changes to temp index...');
+			logService.info(`[debug:#148] git add . at: ${Date.now()}`);
 			await this.execGit(['add', '.'], cwd, { env });
+			logService.info(`[debug:#148] git add . done at: ${Date.now()}`);
 
 			// 2. auto-save 브랜치 없으면 생성
 			if (!(await this.branchExists(autoSaveBranch, cwd))) {
@@ -879,7 +884,9 @@ Refer to **AGENTS.md** for the agent instructions for this project.
 
 			// 3. Tree 생성 (from TEMP index)
 			logService.info('[gitbbon-manager][projectManager] Creating git tree...');
+			logService.info(`[debug:#148] git write-tree at: ${Date.now()}`);
 			const treeId = await this.execGit(['write-tree'], cwd, { env });
+			logService.info(`[debug:#148] git write-tree done: treeId=${treeId.trim()} at: ${Date.now()}`);
 
 			// 4. auto-save 브랜치의 부모 커밋 가져오기 (이미 존재함이 확인됨)
 			let parentCommit: string | null = null;
@@ -894,6 +901,7 @@ Refer to **AGENTS.md** for the agent instructions for this project.
 			const changePreview = await this.getChangePreview(cwd, compareRef, 20, { env });
 			const commitMessage = changePreview || '변경사항 저장';
 			logService.info(`[gitbbon-manager][projectManager] Creating commit with message: ${commitMessage}`);
+			logService.info(`[debug:#148] git commit-tree at: ${Date.now()}, parentCommit: ${parentCommit?.trim()}`);
 			let newCommitId: string;
 			if (parentCommit) {
 				newCommitId = await this.execGit(['commit-tree', treeId, '-p', parentCommit, '-m', commitMessage], cwd);
@@ -901,10 +909,13 @@ Refer to **AGENTS.md** for the agent instructions for this project.
 				// 이론상 여기에 도달하면 안 됨 (위에서 생성했으므로)
 				newCommitId = await this.execGit(['commit-tree', treeId, '-m', commitMessage], cwd);
 			}
+			logService.info(`[debug:#148] git commit-tree done: newCommitId=${newCommitId.trim()} at: ${Date.now()}`);
 
 			// 6. auto-save 브랜치 ref 업데이트
 			logService.info(`[gitbbon-manager][projectManager] Updating ${autoSaveBranch} ref to ${newCommitId}`);
+			logService.info(`[debug:#148] git update-ref ${autoSaveBranch} at: ${Date.now()}`);
 			await this.execGit(['update-ref', `refs/heads/${autoSaveBranch}`, newCommitId], cwd);
+			logService.info(`[debug:#148] git update-ref done at: ${Date.now()}`);
 
 			// 7. Index 초기화 불필요 (Temp Index 사용으로 인해 메인 인덱스 오염 없음)
 			// logService.info('[gitbbon-manager][projectManager] Resetting index after auto commit...');


### PR DESCRIPTION
## 개요
Closes #148

## 변경사항
- editorProvider.ts: autoSaveTimer/autoCommitTimer 시작·취소 시점 로그 추가
- editorProvider.ts: update 메시지 처리 흐름 로그 추가 (early-return 및 isWebviewUpdating 진입·종료)
- projectManager.ts: autoCommit() 각 단계별 상세 로그 추가 (git add, write-tree, commit-tree, update-ref)
- projectManager.ts: hasChanges() 결과 보강 로그 추가 (디스크 파일 vs HEAD 비교임을 명시)

## 진단 방법
출력 채널 필터: `[debug:#148]`